### PR TITLE
feat: Implement FontResolver and FontProvider architecture

### DIFF
--- a/src/CoreFontProvider.php
+++ b/src/CoreFontProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+final class CoreFontProvider implements FontProvider
+{
+    private const ALIASES = [
+        'arial' => 'helvetica',
+    ];
+
+    public function resolve(string $family, FontStyle $style): ?Font
+    {
+        $family = self::ALIASES[$family] ?? $family;
+
+        if ($family === 'symbol' || $family === 'zapfdingbats') {
+            $styleStr = '';
+        } else {
+            $styleStr = $style->value;
+        }
+
+        $key = $family . $styleStr;
+
+        $case = CoreFont::tryFrom($key);
+        if ($case === null) {
+            return null;
+        }
+
+        return $case->toFont();
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function families(): array
+    {
+        return ['courier', 'helvetica', 'times', 'symbol', 'zapfdingbats'];
+    }
+}

--- a/src/DeferredFont.php
+++ b/src/DeferredFont.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+use Horde\Pdf\TrueType\FontData;
+
+final class DeferredFont implements Font
+{
+    public function __construct(
+        private readonly FontData $data,
+    ) {}
+
+    public function pdfName(): string
+    {
+        return $this->data->postScriptName;
+    }
+
+    public function encoding(): FontEncoding
+    {
+        return FontEncoding::IdentityH;
+    }
+
+    public function style(): FontStyle
+    {
+        $isBold = $this->data->usWeightClass >= 700;
+        $isItalic = $this->data->italicAngle !== 0
+            || ($this->data->fsSelection & 0x0001) !== 0;
+
+        if ($isBold && $isItalic) {
+            return FontStyle::BoldItalic;
+        }
+        if ($isBold) {
+            return FontStyle::Bold;
+        }
+        if ($isItalic) {
+            return FontStyle::Italic;
+        }
+        return FontStyle::Regular;
+    }
+
+    public function widthOfString(string $text, float $size): float
+    {
+        $width = 0.0;
+        $chars = mb_str_split($text, 1, 'UTF-8');
+        foreach ($chars as $char) {
+            $codepoint = mb_ord($char, 'UTF-8');
+            $glyphId = $this->data->glyphIdForCodepoint($codepoint);
+            $advanceWidth = $this->data->advanceWidth($glyphId);
+            $width += $advanceWidth;
+        }
+
+        return $width * $size / $this->data->unitsPerEm;
+    }
+
+    public function encode(string $text): string
+    {
+        $encoded = '';
+        $chars = mb_str_split($text, 1, 'UTF-8');
+        foreach ($chars as $char) {
+            $codepoint = mb_ord($char, 'UTF-8');
+            $encoded .= chr(($codepoint >> 8) & 0xFF) . chr($codepoint & 0xFF);
+        }
+        return $encoded;
+    }
+
+    public function requiresEmbedding(): bool
+    {
+        return true;
+    }
+
+    public function fontData(): FontData
+    {
+        return $this->data;
+    }
+}

--- a/src/FontProvider.php
+++ b/src/FontProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+interface FontProvider
+{
+    /**
+     * @return ?Font Resolved font or null if this provider cannot resolve the request
+     */
+    public function resolve(string $family, FontStyle $style): ?Font;
+
+    /**
+     * @return array<string> Available family names (lowercase)
+     */
+    public function families(): array;
+}

--- a/src/FontResolver.php
+++ b/src/FontResolver.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+final class FontResolver
+{
+    /** @var array<FontProvider> */
+    private readonly array $providers;
+
+    public function __construct(FontProvider ...$providers)
+    {
+        $this->providers = $providers;
+    }
+
+    public function resolve(string $family, FontStyle $style): Font
+    {
+        $normalized = strtolower(trim($family));
+
+        foreach ($this->providers as $provider) {
+            $font = $provider->resolve($normalized, $style);
+            if ($font !== null) {
+                return $font;
+            }
+        }
+
+        return $this->fallback($style);
+    }
+
+    private function fallback(FontStyle $style): Font
+    {
+        $coreFont = match ($style) {
+            FontStyle::Bold => CoreFont::HelveticaBold,
+            FontStyle::Italic => CoreFont::HelveticaItalic,
+            FontStyle::BoldItalic => CoreFont::HelveticaBoldItalic,
+            default => CoreFont::Helvetica,
+        };
+
+        return $coreFont->toFont();
+    }
+}

--- a/src/PdfWriter.php
+++ b/src/PdfWriter.php
@@ -95,10 +95,17 @@ final class PdfWriter
     /** @var array<int, array<int, array{x: float, y: float, w: float, h: float, target: int|string}>> Annotations per page */
     private array $pageLinks = [];
 
+    /** @var array<string, array<int, true>> PostScript name → set of codepoints */
+    private array $deferredFontChars = [];
+
+    /** @var array<string, DeferredFont> PostScript name → DeferredFont instance */
+    private array $deferredFonts = [];
+
     public function __construct(
         private readonly WriterOptions $options = new WriterOptions(),
         ?HeaderFooterHandler $headerFooter = null,
         bool $compress = true,
+        private readonly ?FontResolver $fontResolver = null,
     ) {
         $this->headerFooter = $headerFooter;
         $this->compress = $compress;
@@ -216,6 +223,8 @@ final class PdfWriter
         if ($this->state !== DocumentState::Closed) {
             $this->close();
         }
+
+        $this->resolveDeferredFonts();
 
         $totalPages = $this->pageNumber;
         $catalog = new DocumentCatalog();
@@ -357,20 +366,48 @@ final class PdfWriter
 
     // --- Font ---
 
-    public function setFont(string $family, string $style = '', ?float $size = null): void
+    public function setFont(string $family, string|FontStyle $style = '', ?float $size = null): void
     {
         if ($family === '') {
             $family = $this->fontFamily;
         }
 
-        [$coreFont, $underline] = CoreFont::fromFamilyStyle($family, $style);
-        $this->currentFont = $coreFont->toFont();
-        $this->fontFamily = $coreFont->family();
-        $this->fontStyle = strtoupper(str_replace('U', '', $style));
-        if ($this->fontStyle === 'IB') {
-            $this->fontStyle = 'BI';
+        $underline = false;
+
+        if ($style instanceof FontStyle) {
+            $fontStyle = $style;
+            $styleStr = $style->value;
+        } else {
+            $styleStr = strtoupper($style);
+            $underline = str_contains($styleStr, 'U');
+            $styleStr = str_replace('U', '', $styleStr);
+            if ($styleStr === 'IB') {
+                $styleStr = 'BI';
+            }
+            $fontStyle = FontStyle::tryFrom($styleStr) ?? FontStyle::Regular;
         }
-        $this->underline = $underline;
+
+        if ($this->fontResolver !== null) {
+            $resolved = $this->fontResolver->resolve($family, $fontStyle);
+            $this->currentFont = $resolved;
+            $this->fontFamily = strtolower(trim($family));
+            $this->fontStyle = $styleStr;
+            $this->underline = $underline;
+
+            if ($resolved instanceof DeferredFont) {
+                $psName = $resolved->pdfName();
+                if (!isset($this->deferredFonts[$psName])) {
+                    $this->deferredFonts[$psName] = $resolved;
+                    $this->deferredFontChars[$psName] = [];
+                }
+            }
+        } else {
+            [$coreFont, $underline] = CoreFont::fromFamilyStyle($family, $styleStr);
+            $this->currentFont = $coreFont->toFont();
+            $this->fontFamily = $coreFont->family();
+            $this->fontStyle = $styleStr;
+            $this->underline = $underline;
+        }
 
         if ($size !== null && $size > 0) {
             $this->fontSizePt = $size;
@@ -579,6 +616,8 @@ final class PdfWriter
             throw new PdfException('No font set');
         }
 
+        $this->trackDeferredCodepoints($text);
+
         $k = $this->scaleFactor;
         $localName = $this->registerFont($this->currentFont);
         $textString = $this->encodePdfString($text);
@@ -685,6 +724,8 @@ final class PdfWriter
             if ($this->currentFont === null) {
                 throw new PdfException('No font set');
             }
+
+            $this->trackDeferredCodepoints($text);
 
             $dx = match ($align) {
                 TextAlign::Right => $width - $this->cellMargin - $this->getStringWidth($text),
@@ -1184,11 +1225,55 @@ final class PdfWriter
 
     private function encodePdfString(string $text): string
     {
-        if ($this->currentFont instanceof Type0Font || $this->currentFont instanceof CidFont) {
+        if ($this->currentFont instanceof Type0Font
+            || $this->currentFont instanceof CidFont
+            || $this->currentFont instanceof DeferredFont
+        ) {
             $encoded = $this->currentFont->encode($text);
             return '<' . strtoupper(bin2hex($encoded)) . '>';
         }
         return '(' . self::escapeString($text) . ')';
+    }
+
+    private function trackDeferredCodepoints(string $text): void
+    {
+        if (!($this->currentFont instanceof DeferredFont)) {
+            return;
+        }
+
+        $psName = $this->currentFont->pdfName();
+        $chars = mb_str_split($text, 1, 'UTF-8');
+        foreach ($chars as $char) {
+            $cp = mb_ord($char, 'UTF-8');
+            $this->deferredFontChars[$psName][$cp] = true;
+        }
+    }
+
+    private function resolveDeferredFonts(): void
+    {
+        if (empty($this->deferredFonts)) {
+            return;
+        }
+
+        $resolved = [];
+        foreach ($this->deferredFonts as $psName => $deferred) {
+            $codepoints = array_keys($this->deferredFontChars[$psName] ?? []);
+            if (empty($codepoints)) {
+                continue;
+            }
+            $resolved[$psName] = new Type0Font($deferred->fontData(), $codepoints);
+        }
+
+        for ($p = 1; $p <= $this->pageNumber; $p++) {
+            foreach ($this->fontMaps[$p] as $localName => $font) {
+                if ($font instanceof DeferredFont) {
+                    $psName = $font->pdfName();
+                    if (isset($resolved[$psName])) {
+                        $this->fontMaps[$p][$localName] = $resolved[$psName];
+                    }
+                }
+            }
+        }
     }
 
     private function doUnderline(float $x, float $y, string $text): string

--- a/src/TrueTypeFontProvider.php
+++ b/src/TrueTypeFontProvider.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+use Horde\Pdf\TrueType\FontParser;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+final class TrueTypeFontProvider implements FontProvider
+{
+    /** @var array<string> */
+    private readonly array $directories;
+
+    /** @var ?array<string, array<string, string>> [family][style_value] => filePath */
+    private ?array $index = null;
+
+    public function __construct(string ...$directories)
+    {
+        $this->directories = $directories;
+    }
+
+    public function resolve(string $family, FontStyle $style): ?Font
+    {
+        $this->buildIndex();
+
+        $entry = $this->index[$family][$style->value] ?? null;
+
+        if ($entry === null && $style !== FontStyle::Regular) {
+            $entry = $this->index[$family][FontStyle::Regular->value] ?? null;
+        }
+
+        if ($entry === null) {
+            return null;
+        }
+
+        $fontData = FontParser::parseFile($entry);
+        return new DeferredFont($fontData);
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function families(): array
+    {
+        $this->buildIndex();
+        return array_keys($this->index);
+    }
+
+    private function buildIndex(): void
+    {
+        if ($this->index !== null) {
+            return;
+        }
+
+        $this->index = [];
+
+        foreach ($this->directories as $dir) {
+            if (!is_dir($dir)) {
+                continue;
+            }
+
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($dir),
+            );
+
+            foreach ($iterator as $file) {
+                if (!$file->isFile()) {
+                    continue;
+                }
+                if (strtolower($file->getExtension()) !== 'ttf') {
+                    continue;
+                }
+
+                $this->indexFont($file->getPathname());
+            }
+        }
+    }
+
+    private function indexFont(string $path): void
+    {
+        try {
+            $fontData = FontParser::parseFile($path);
+        } catch (\Throwable) {
+            return;
+        }
+
+        $family = strtolower(trim($fontData->fontFamily));
+        if ($family === '') {
+            return;
+        }
+
+        $style = $this->detectStyle($fontData);
+        $this->index[$family][$style->value] = $path;
+    }
+
+    private function detectStyle(\Horde\Pdf\TrueType\FontData $fontData): FontStyle
+    {
+        $isBold = $fontData->usWeightClass >= 700;
+        $isItalic = $fontData->italicAngle !== 0
+            || ($fontData->fsSelection & 0x0001) !== 0;
+
+        if ($isBold && $isItalic) {
+            return FontStyle::BoldItalic;
+        }
+        if ($isBold) {
+            return FontStyle::Bold;
+        }
+        if ($isItalic) {
+            return FontStyle::Italic;
+        }
+        return FontStyle::Regular;
+    }
+}

--- a/test/unit/CoreFontProviderTest.php
+++ b/test/unit/CoreFontProviderTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf\Test\Unit;
+
+use Horde\Pdf\CoreFontProvider;
+use Horde\Pdf\FontStyle;
+use Horde\Pdf\Type1Font;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(CoreFontProvider::class)]
+final class CoreFontProviderTest extends TestCase
+{
+    private CoreFontProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->provider = new CoreFontProvider();
+    }
+
+    #[Test]
+    public function resolvesHelveticaRegular(): void
+    {
+        $font = $this->provider->resolve('helvetica', FontStyle::Regular);
+        $this->assertInstanceOf(Type1Font::class, $font);
+        $this->assertSame('Helvetica', $font->pdfName());
+    }
+
+    #[Test]
+    public function resolvesHelveticaBold(): void
+    {
+        $font = $this->provider->resolve('helvetica', FontStyle::Bold);
+        $this->assertInstanceOf(Type1Font::class, $font);
+        $this->assertSame('Helvetica-Bold', $font->pdfName());
+    }
+
+    #[Test]
+    public function resolvesHelveticaItalic(): void
+    {
+        $font = $this->provider->resolve('helvetica', FontStyle::Italic);
+        $this->assertInstanceOf(Type1Font::class, $font);
+        $this->assertSame('Helvetica-Oblique', $font->pdfName());
+    }
+
+    #[Test]
+    public function resolvesHelveticaBoldItalic(): void
+    {
+        $font = $this->provider->resolve('helvetica', FontStyle::BoldItalic);
+        $this->assertInstanceOf(Type1Font::class, $font);
+        $this->assertSame('Helvetica-BoldOblique', $font->pdfName());
+    }
+
+    #[Test]
+    public function resolvesCourierRegular(): void
+    {
+        $font = $this->provider->resolve('courier', FontStyle::Regular);
+        $this->assertInstanceOf(Type1Font::class, $font);
+        $this->assertSame('Courier', $font->pdfName());
+    }
+
+    #[Test]
+    public function resolvesTimesRegular(): void
+    {
+        $font = $this->provider->resolve('times', FontStyle::Regular);
+        $this->assertInstanceOf(Type1Font::class, $font);
+        $this->assertSame('Times-Roman', $font->pdfName());
+    }
+
+    #[Test]
+    public function resolvesArialAsHelvetica(): void
+    {
+        $font = $this->provider->resolve('arial', FontStyle::Bold);
+        $this->assertInstanceOf(Type1Font::class, $font);
+        $this->assertSame('Helvetica-Bold', $font->pdfName());
+    }
+
+    #[Test]
+    public function resolvesSymbol(): void
+    {
+        $font = $this->provider->resolve('symbol', FontStyle::Regular);
+        $this->assertInstanceOf(Type1Font::class, $font);
+        $this->assertSame('Symbol', $font->pdfName());
+    }
+
+    #[Test]
+    public function symbolIgnoresStyle(): void
+    {
+        $font = $this->provider->resolve('symbol', FontStyle::Bold);
+        $this->assertInstanceOf(Type1Font::class, $font);
+        $this->assertSame('Symbol', $font->pdfName());
+    }
+
+    #[Test]
+    public function returnsNullForUnknownFamily(): void
+    {
+        $font = $this->provider->resolve('roboto', FontStyle::Regular);
+        $this->assertNull($font);
+    }
+
+    #[Test]
+    public function familiesReturnsCoreFamilyNames(): void
+    {
+        $families = $this->provider->families();
+        $this->assertContains('helvetica', $families);
+        $this->assertContains('courier', $families);
+        $this->assertContains('times', $families);
+        $this->assertContains('symbol', $families);
+        $this->assertContains('zapfdingbats', $families);
+        $this->assertCount(5, $families);
+    }
+}

--- a/test/unit/DeferredFontTest.php
+++ b/test/unit/DeferredFontTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf\Test\Unit;
+
+use Horde\Pdf\DeferredFont;
+use Horde\Pdf\FontEncoding;
+use Horde\Pdf\FontStyle;
+use Horde\Pdf\TrueType\FontParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DeferredFont::class)]
+final class DeferredFontTest extends TestCase
+{
+    private DeferredFont $font;
+
+    protected function setUp(): void
+    {
+        $path = __DIR__ . '/fixtures/roboto-light.ttf';
+        if (!file_exists($path)) {
+            $this->markTestSkipped('Font fixture not available');
+        }
+        $fontData = FontParser::parseFile($path);
+        $this->font = new DeferredFont($fontData);
+    }
+
+    #[Test]
+    public function pdfNameReturnsPostScriptName(): void
+    {
+        $this->assertStringContainsString('Roboto', $this->font->pdfName());
+    }
+
+    #[Test]
+    public function encodingReturnsIdentityH(): void
+    {
+        $this->assertSame(FontEncoding::IdentityH, $this->font->encoding());
+    }
+
+    #[Test]
+    public function styleReturnsRegularForLightFont(): void
+    {
+        $this->assertSame(FontStyle::Regular, $this->font->style());
+    }
+
+    #[Test]
+    public function requiresEmbeddingReturnsTrue(): void
+    {
+        $this->assertTrue($this->font->requiresEmbedding());
+    }
+
+    #[Test]
+    public function widthOfStringReturnsPositive(): void
+    {
+        $width = $this->font->widthOfString('Hello', 12.0);
+        $this->assertGreaterThan(0.0, $width);
+    }
+
+    #[Test]
+    public function encodeProducesTwoBytesPerCharacter(): void
+    {
+        $encoded = $this->font->encode('AB');
+        $this->assertSame(4, strlen($encoded));
+        $this->assertSame("\x00\x41\x00\x42", $encoded);
+    }
+
+    #[Test]
+    public function fontDataReturnsUnderlyingData(): void
+    {
+        $data = $this->font->fontData();
+        $this->assertGreaterThan(0, $data->unitsPerEm);
+    }
+}

--- a/test/unit/FontResolverIntegrationTest.php
+++ b/test/unit/FontResolverIntegrationTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf\Test\Unit;
+
+use Horde\Pdf\CoreFontProvider;
+use Horde\Pdf\FontResolver;
+use Horde\Pdf\FontStyle;
+use Horde\Pdf\PdfWriter;
+use Horde\Pdf\TrueTypeFontProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FontResolver::class)]
+final class FontResolverIntegrationTest extends TestCase
+{
+    private string $fixtureDir;
+    private FontResolver $resolver;
+
+    protected function setUp(): void
+    {
+        $this->fixtureDir = __DIR__ . '/fixtures';
+        if (!file_exists($this->fixtureDir . '/roboto-light.ttf')) {
+            $this->markTestSkipped('Font fixture not available');
+        }
+
+        $this->resolver = new FontResolver(
+            new TrueTypeFontProvider($this->fixtureDir),
+            new CoreFontProvider(),
+        );
+    }
+
+    #[Test]
+    public function setFontWithTrueTypeProducesEmbeddedFont(): void
+    {
+        $writer = new PdfWriter(compress: false, fontResolver: $this->resolver);
+        $writer->addPage();
+        $writer->setFont('Roboto Light', FontStyle::Regular, 12.0);
+        $writer->text(10.0, 20.0, 'Hello World');
+        $pdf = $writer->getOutput();
+
+        $this->assertStringContainsString('/Subtype /Type0', $pdf);
+        $this->assertStringContainsString('/Encoding /Identity-H', $pdf);
+        $this->assertStringContainsString('/Subtype /CIDFontType2', $pdf);
+        $this->assertStringContainsString('/FontFile2', $pdf);
+    }
+
+    #[Test]
+    public function setFontWithCoreFontProducesType1(): void
+    {
+        $writer = new PdfWriter(compress: false, fontResolver: $this->resolver);
+        $writer->addPage();
+        $writer->setFont('Helvetica', FontStyle::Bold, 14.0);
+        $writer->text(10.0, 20.0, 'Hello');
+        $pdf = $writer->getOutput();
+
+        $this->assertStringContainsString('/Subtype /Type1', $pdf);
+        $this->assertStringContainsString('/BaseFont /Helvetica-Bold', $pdf);
+    }
+
+    #[Test]
+    public function unknownFontFallsBackToHelvetica(): void
+    {
+        $writer = new PdfWriter(compress: false, fontResolver: $this->resolver);
+        $writer->addPage();
+        $writer->setFont('NonExistentFont', FontStyle::Regular, 12.0);
+        $writer->text(10.0, 20.0, 'Hello');
+        $pdf = $writer->getOutput();
+
+        $this->assertStringContainsString('/BaseFont /Helvetica', $pdf);
+    }
+
+    #[Test]
+    public function trueTypeFontSubsetsToUsedCharacters(): void
+    {
+        $writer = new PdfWriter(compress: false, fontResolver: $this->resolver);
+        $writer->addPage();
+        $writer->setFont('Roboto Light', FontStyle::Regular, 12.0);
+        $writer->text(10.0, 20.0, 'AB');
+        $pdf = $writer->getOutput();
+
+        $this->assertStringContainsString('<00410042>', $pdf);
+        $this->assertStringContainsString('/ToUnicode', $pdf);
+    }
+
+    #[Test]
+    public function multiplePagesWithSameTrueTypeFont(): void
+    {
+        $writer = new PdfWriter(compress: false, fontResolver: $this->resolver);
+        $writer->addPage();
+        $writer->setFont('Roboto Light', FontStyle::Regular, 12.0);
+        $writer->text(10.0, 20.0, 'Page 1');
+        $writer->addPage();
+        $writer->setFont('Roboto Light', FontStyle::Regular, 12.0);
+        $writer->text(10.0, 20.0, 'Page 2');
+        $pdf = $writer->getOutput();
+
+        $this->assertStringStartsWith('%PDF-', $pdf);
+        $this->assertStringContainsString('/Subtype /Type0', $pdf);
+        $this->assertSame(1, substr_count($pdf, '/Subtype /CIDFontType2'));
+    }
+
+    #[Test]
+    public function mixedCoreFontAndTrueTypeOnSamePage(): void
+    {
+        $writer = new PdfWriter(compress: false, fontResolver: $this->resolver);
+        $writer->addPage();
+        $writer->setFont('Helvetica', FontStyle::Regular, 12.0);
+        $writer->text(10.0, 20.0, 'Core font text');
+        $writer->setFont('Roboto Light', FontStyle::Regular, 12.0);
+        $writer->text(10.0, 40.0, 'TrueType text');
+        $pdf = $writer->getOutput();
+
+        $this->assertStringContainsString('/Subtype /Type1', $pdf);
+        $this->assertStringContainsString('/Subtype /Type0', $pdf);
+    }
+
+    #[Test]
+    public function setFontWithStringStyleParameter(): void
+    {
+        $writer = new PdfWriter(compress: false, fontResolver: $this->resolver);
+        $writer->addPage();
+        $writer->setFont('Helvetica', 'B', 12.0);
+        $writer->text(10.0, 20.0, 'Bold');
+        $pdf = $writer->getOutput();
+
+        $this->assertStringContainsString('/BaseFont /Helvetica-Bold', $pdf);
+    }
+
+    #[Test]
+    public function cellWithTrueTypeFontTracksCodepoints(): void
+    {
+        $writer = new PdfWriter(compress: false, fontResolver: $this->resolver);
+        $writer->addPage();
+        $writer->setFont('Roboto Light', FontStyle::Regular, 12.0);
+        $writer->cell(0, 10, 'Cell text');
+        $pdf = $writer->getOutput();
+
+        $this->assertStringContainsString('/Subtype /Type0', $pdf);
+        $this->assertStringContainsString('/FontFile2', $pdf);
+    }
+}

--- a/test/unit/FontResolverTest.php
+++ b/test/unit/FontResolverTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf\Test\Unit;
+
+use Horde\Pdf\CoreFontProvider;
+use Horde\Pdf\DeferredFont;
+use Horde\Pdf\FontResolver;
+use Horde\Pdf\FontStyle;
+use Horde\Pdf\TrueTypeFontProvider;
+use Horde\Pdf\Type1Font;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FontResolver::class)]
+final class FontResolverTest extends TestCase
+{
+    #[Test]
+    public function resolvesCoreFont(): void
+    {
+        $resolver = new FontResolver(new CoreFontProvider());
+        $font = $resolver->resolve('Helvetica', FontStyle::Bold);
+        $this->assertInstanceOf(Type1Font::class, $font);
+        $this->assertSame('Helvetica-Bold', $font->pdfName());
+    }
+
+    #[Test]
+    public function fallsBackToHelveticaForUnknownFamily(): void
+    {
+        $resolver = new FontResolver(new CoreFontProvider());
+        $font = $resolver->resolve('NonExistentFont', FontStyle::Regular);
+        $this->assertInstanceOf(Type1Font::class, $font);
+        $this->assertSame('Helvetica', $font->pdfName());
+    }
+
+    #[Test]
+    public function fallbackPreservesStyle(): void
+    {
+        $resolver = new FontResolver(new CoreFontProvider());
+        $font = $resolver->resolve('NonExistentFont', FontStyle::BoldItalic);
+        $this->assertInstanceOf(Type1Font::class, $font);
+        $this->assertSame('Helvetica-BoldOblique', $font->pdfName());
+    }
+
+    #[Test]
+    public function trueTypeProviderTakesPriority(): void
+    {
+        $fixtureDir = __DIR__ . '/fixtures';
+        if (!file_exists($fixtureDir . '/roboto-light.ttf')) {
+            $this->markTestSkipped('Font fixture not available');
+        }
+
+        $resolver = new FontResolver(
+            new TrueTypeFontProvider($fixtureDir),
+            new CoreFontProvider(),
+        );
+
+        $font = $resolver->resolve('Roboto Light', FontStyle::Regular);
+        $this->assertInstanceOf(DeferredFont::class, $font);
+    }
+
+    #[Test]
+    public function coreFontProviderWinsWhenListedFirst(): void
+    {
+        $fixtureDir = __DIR__ . '/fixtures';
+
+        $resolver = new FontResolver(
+            new CoreFontProvider(),
+            new TrueTypeFontProvider($fixtureDir),
+        );
+
+        $font = $resolver->resolve('Helvetica', FontStyle::Regular);
+        $this->assertInstanceOf(Type1Font::class, $font);
+    }
+
+    #[Test]
+    public function caseInsensitiveResolution(): void
+    {
+        $resolver = new FontResolver(new CoreFontProvider());
+        $font = $resolver->resolve('HELVETICA', FontStyle::Regular);
+        $this->assertInstanceOf(Type1Font::class, $font);
+        $this->assertSame('Helvetica', $font->pdfName());
+    }
+}

--- a/test/unit/TrueTypeFontProviderTest.php
+++ b/test/unit/TrueTypeFontProviderTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf\Test\Unit;
+
+use Horde\Pdf\DeferredFont;
+use Horde\Pdf\FontStyle;
+use Horde\Pdf\TrueTypeFontProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TrueTypeFontProvider::class)]
+final class TrueTypeFontProviderTest extends TestCase
+{
+    private string $fixtureDir;
+
+    protected function setUp(): void
+    {
+        $this->fixtureDir = __DIR__ . '/fixtures';
+        if (!file_exists($this->fixtureDir . '/roboto-light.ttf')) {
+            $this->markTestSkipped('Font fixture not available');
+        }
+    }
+
+    #[Test]
+    public function resolvesExistingFont(): void
+    {
+        $provider = new TrueTypeFontProvider($this->fixtureDir);
+        $font = $provider->resolve('roboto light', FontStyle::Regular);
+        $this->assertInstanceOf(DeferredFont::class, $font);
+    }
+
+    #[Test]
+    public function returnsNullForUnknownFamily(): void
+    {
+        $provider = new TrueTypeFontProvider($this->fixtureDir);
+        $font = $provider->resolve('nonexistent', FontStyle::Regular);
+        $this->assertNull($font);
+    }
+
+    #[Test]
+    public function familiesIncludesScannedFonts(): void
+    {
+        $provider = new TrueTypeFontProvider($this->fixtureDir);
+        $families = $provider->families();
+        $this->assertNotEmpty($families);
+        $found = false;
+        foreach ($families as $f) {
+            if (str_contains($f, 'roboto')) {
+                $found = true;
+                break;
+            }
+        }
+        $this->assertTrue($found, 'Expected a roboto family in scanned fonts');
+    }
+
+    #[Test]
+    public function scansRecursively(): void
+    {
+        $subdir = $this->fixtureDir . '/subdir';
+        if (!is_dir($subdir)) {
+            mkdir($subdir);
+        }
+        copy($this->fixtureDir . '/roboto-light.ttf', $subdir . '/roboto-light.ttf');
+
+        try {
+            $provider = new TrueTypeFontProvider($subdir);
+            $families = $provider->families();
+            $this->assertNotEmpty($families);
+        } finally {
+            unlink($subdir . '/roboto-light.ttf');
+            rmdir($subdir);
+        }
+    }
+
+    #[Test]
+    public function handlesNonExistentDirectory(): void
+    {
+        $provider = new TrueTypeFontProvider('/nonexistent/path');
+        $families = $provider->families();
+        $this->assertSame([], $families);
+    }
+
+    #[Test]
+    public function fallsBackToRegularStyleWhenRequestedNotFound(): void
+    {
+        $provider = new TrueTypeFontProvider($this->fixtureDir);
+        $font = $provider->resolve('roboto light', FontStyle::Bold);
+        $this->assertInstanceOf(DeferredFont::class, $font);
+    }
+}


### PR DESCRIPTION
## Summary
- FontProvider interface with CoreFontProvider and TrueTypeFontProvider
- TrueTypeFontProvider scans configured directories recursively for .ttf files
- DeferredFont enables deferred subsetting (codepoints collected during writing, subset at getOutput())
- FontResolver iterates providers in order, falls back to Helvetica when unresolved
- PdfWriter.setFont() accepts FontStyle enum and transparently resolves TrueType fonts

## Test plan
- [x] CoreFontProvider: 11 tests (all families/styles, aliases, unknown)
- [x] DeferredFont: 7 tests (encoding, widths, style detection)
- [x] FontResolver: 6 tests (priority, fallback, case-insensitive)
- [x] TrueTypeFontProvider: 6 tests (scan, recursive, missing dir, style fallback)
- [x] Integration: 8 tests (full flow with embedded font output)
- [x] Full suite: 386 tests passing, no regressions

Closes #12