### PR TITLE
feat: Implement XMP metadata and PDF/A groundwork for issue #14

### DIFF
--- a/.horde.yml
+++ b/.horde.yml
@@ -51,6 +51,10 @@ dependencies:
   optional:
     composer:
       horde/test: ^3
+      horde/xml_element: ^3
+  dev:
+    composer:
+      horde/xml_element: dev-FRAMEWORK_6_0
 keywords:
   - iso32000
 vendor: horde

--- a/composer.json
+++ b/composer.json
@@ -36,9 +36,12 @@
         "horde/exception": "^3 || dev-FRAMEWORK_6_0",
         "horde/util": "^3 || dev-FRAMEWORK_6_0"
     },
-    "require-dev": {},
+    "require-dev": {
+        "horde/xml_element": "dev-FRAMEWORK_6_0"
+    },
     "suggest": {
-        "horde/test": "^3 || dev-FRAMEWORK_6_0"
+        "horde/test": "^3 || dev-FRAMEWORK_6_0",
+        "horde/xml_element": "^3 || dev-FRAMEWORK_6_0 — required for XmpBuilder"
     },
     "autoload": {
         "psr-0": {

--- a/src/DocumentCatalog.php
+++ b/src/DocumentCatalog.php
@@ -10,6 +10,9 @@ final class DocumentCatalog
     private ?DocumentInfo $info = null;
     private ?ViewerPreferences $viewerPreferences = null;
     private ?OutlineTree $outlines = null;
+    private ?MetadataStream $metadata = null;
+    /** @var array<OutputIntent> */
+    private array $outputIntents = [];
 
     public function __construct(
         public readonly PdfVersion $version = PdfVersion::V1_7,
@@ -55,5 +58,28 @@ final class DocumentCatalog
     public function outlines(): ?OutlineTree
     {
         return $this->outlines;
+    }
+
+    public function setMetadata(MetadataStream $metadata): void
+    {
+        $this->metadata = $metadata;
+    }
+
+    public function metadata(): ?MetadataStream
+    {
+        return $this->metadata;
+    }
+
+    public function addOutputIntent(OutputIntent $intent): void
+    {
+        $this->outputIntents[] = $intent;
+    }
+
+    /**
+     * @return array<OutputIntent>
+     */
+    public function outputIntents(): array
+    {
+        return $this->outputIntents;
     }
 }

--- a/src/MetadataStream.php
+++ b/src/MetadataStream.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+final class MetadataStream
+{
+    public function __construct(
+        public readonly string $xml,
+    ) {}
+}

--- a/src/OutputIntent.php
+++ b/src/OutputIntent.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+final class OutputIntent
+{
+    public function __construct(
+        public readonly string $subtype = 'GTS_PDFA1',
+        public readonly string $outputConditionIdentifier = 'sRGB',
+        public readonly string $registryName = 'http://www.color.org',
+        public readonly string $info = 'sRGB IEC61966-2.1',
+    ) {}
+}

--- a/src/PdfSerializer.php
+++ b/src/PdfSerializer.php
@@ -119,6 +119,20 @@ final class PdfSerializer
             $this->allocateOutlineObjNums($outlines->items(), $objectNumber, $outlineObjNums);
         }
 
+        $metadataObjNum = 0;
+        $metadata = $catalog->metadata();
+        if ($metadata !== null) {
+            $objectNumber++;
+            $metadataObjNum = $objectNumber;
+        }
+
+        $outputIntentObjNums = [];
+        $outputIntents = $catalog->outputIntents();
+        foreach ($outputIntents as $intent) {
+            $objectNumber++;
+            $outputIntentObjNums[] = $objectNumber;
+        }
+
         $totalObjects = $objectNumber;
 
         $buffer .= $catalog->version->header() . "\n";
@@ -347,12 +361,45 @@ final class PdfSerializer
             $buffer .= "/Outlines " . $outlineRootObjNum . " 0 R\n";
             $buffer .= "/PageMode /UseOutlines\n";
         }
+        if ($metadataObjNum > 0) {
+            $buffer .= "/Metadata " . $metadataObjNum . " 0 R\n";
+        }
+        if (!empty($outputIntentObjNums)) {
+            $buffer .= '/OutputIntents [';
+            foreach ($outputIntentObjNums as $oiNum) {
+                $buffer .= $oiNum . ' 0 R ';
+            }
+            $buffer .= "]\n";
+        }
         $this->writeCatalogViewerPrefs($catalog, $buffer, $pages, $pageObjNums);
         $buffer .= ">>\n";
         $buffer .= "endobj\n";
 
         if ($outlineRootObjNum > 0) {
             $this->serializeOutlines($buffer, $offsets, $outlines, $outlineRootObjNum, $outlineObjNums, $objectMap);
+        }
+
+        if ($metadataObjNum > 0) {
+            $offsets[$metadataObjNum] = strlen($buffer);
+            $buffer .= $metadataObjNum . " 0 obj\n";
+            $buffer .= "<</Type /Metadata /Subtype /XML /Length " . strlen($metadata->xml) . ">>\n";
+            $buffer .= "stream\n";
+            $buffer .= $metadata->xml . "\n";
+            $buffer .= "endstream\n";
+            $buffer .= "endobj\n";
+        }
+
+        foreach ($outputIntents as $idx => $intent) {
+            $objNum = $outputIntentObjNums[$idx];
+            $offsets[$objNum] = strlen($buffer);
+            $buffer .= $objNum . " 0 obj\n";
+            $buffer .= "<</Type /OutputIntent\n";
+            $buffer .= "/S /" . $intent->subtype . "\n";
+            $buffer .= "/OutputConditionIdentifier " . self::textString($intent->outputConditionIdentifier) . "\n";
+            $buffer .= "/RegistryName " . self::textString($intent->registryName) . "\n";
+            $buffer .= "/Info " . self::textString($intent->info) . "\n";
+            $buffer .= ">>\n";
+            $buffer .= "endobj\n";
         }
 
         $xrefOffset = strlen($buffer);
@@ -458,7 +505,6 @@ final class PdfSerializer
 
     /**
      * @param array<string, mixed> $entry
-     * @param array<int, int> $offsets
      */
     private function serializeType0Font(string &$buffer, array &$offsets, array $entry): void
     {
@@ -593,7 +639,6 @@ final class PdfSerializer
     }
 
     /**
-     * @param array<int, string> $offsets
      * @param array<int, OutlineItem> $outlineObjNums
      * @param SplObjectStorage<object, int> $objectMap
      */

--- a/src/PdfWriter.php
+++ b/src/PdfWriter.php
@@ -282,6 +282,12 @@ final class PdfWriter
         if (!empty($this->bookmarks)) {
             $catalog->setOutlines($this->buildOutlineTree($pageObjects));
         }
+        if ($this->metadata !== null) {
+            $catalog->setMetadata($this->metadata);
+        }
+        foreach ($this->outputIntents as $intent) {
+            $catalog->addOutputIntent($intent);
+        }
 
         return (new PdfSerializer(compress: $this->compress))->serialize($catalog);
     }
@@ -1117,6 +1123,22 @@ final class PdfWriter
             'page' => $this->pageNumber,
             'y' => $y ?? $this->y,
         ];
+    }
+
+    // --- XMP Metadata & Output Intents ---
+
+    private ?MetadataStream $metadata = null;
+    /** @var array<OutputIntent> */
+    private array $outputIntents = [];
+
+    public function setMetadata(MetadataStream $metadata): void
+    {
+        $this->metadata = $metadata;
+    }
+
+    public function addOutputIntent(OutputIntent $intent): void
+    {
+        $this->outputIntents[] = $intent;
     }
 
     // --- Metadata ---

--- a/src/TrueTypeFontProvider.php
+++ b/src/TrueTypeFontProvider.php
@@ -7,6 +7,7 @@ namespace Horde\Pdf;
 use Horde\Pdf\TrueType\FontParser;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use Throwable;
 
 final class TrueTypeFontProvider implements FontProvider
 {
@@ -82,7 +83,7 @@ final class TrueTypeFontProvider implements FontProvider
     {
         try {
             $fontData = FontParser::parseFile($path);
-        } catch (\Throwable) {
+        } catch (Throwable) {
             return;
         }
 
@@ -95,7 +96,7 @@ final class TrueTypeFontProvider implements FontProvider
         $this->index[$family][$style->value] = $path;
     }
 
-    private function detectStyle(\Horde\Pdf\TrueType\FontData $fontData): FontStyle
+    private function detectStyle(TrueType\FontData $fontData): FontStyle
     {
         $isBold = $fontData->usWeightClass >= 700;
         $isItalic = $fontData->italicAngle !== 0

--- a/src/XmpBuilder.php
+++ b/src/XmpBuilder.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+use DateTimeInterface;
+use DOMDocument;
+use DOMElement;
+
+final class XmpBuilder
+{
+    private const NS_X = 'adobe:ns:meta/';
+    private const NS_RDF = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
+    private const NS_DC = 'http://purl.org/dc/elements/1.1/';
+    private const NS_XMP = 'http://ns.adobe.com/xap/1.0/';
+    private const NS_PDF = 'http://ns.adobe.com/pdf/1.3/';
+    private const NS_PDFAID = 'http://www.aiim.org/pdfa/ns/id/';
+    private const NS_XMPMM = 'http://ns.adobe.com/xap/1.0/mm/';
+
+    public function __construct(
+        private readonly ?string $title = null,
+        private readonly ?string $creator = null,
+        private readonly ?string $description = null,
+        private readonly ?string $creatorTool = null,
+        private readonly ?DateTimeInterface $createDate = null,
+        private readonly ?DateTimeInterface $modifyDate = null,
+        private readonly ?string $producer = null,
+        private readonly ?string $keywords = null,
+        private readonly ?string $documentId = null,
+        private readonly ?string $pdfaConformance = null,
+        private readonly ?int $pdfaPart = null,
+    ) {}
+
+    public function build(): MetadataStream
+    {
+        $doc = new DOMDocument('1.0', 'UTF-8');
+        $doc->formatOutput = true;
+
+        $xmpmeta = $doc->createElementNS(self::NS_X, 'x:xmpmeta');
+        $doc->appendChild($xmpmeta);
+
+        $rdf = $doc->createElementNS(self::NS_RDF, 'rdf:RDF');
+        $xmpmeta->appendChild($rdf);
+
+        $this->addDublinCore($doc, $rdf);
+        $this->addXmpBasic($doc, $rdf);
+        $this->addPdfProperties($doc, $rdf);
+        $this->addPdfaId($doc, $rdf);
+        $this->addXmpMM($doc, $rdf);
+
+        $xmlContent = $doc->saveXML($doc->documentElement);
+
+        $xmp = "<?xpacket begin=\"\xEF\xBB\xBF\" id=\"W5M0MpCehiHzreSzNTczkc9d\"?>\n";
+        $xmp .= $xmlContent . "\n";
+        $xmp .= str_repeat(str_repeat(' ', 100) . "\n", 20);
+        $xmp .= '<?xpacket end="w"?>';
+
+        return new MetadataStream($xmp);
+    }
+
+    private function addDublinCore(DOMDocument $doc, DOMElement $rdf): void
+    {
+        if ($this->title === null && $this->creator === null && $this->description === null) {
+            return;
+        }
+
+        $desc = $doc->createElementNS(self::NS_RDF, 'rdf:Description');
+        $desc->setAttributeNS(self::NS_RDF, 'rdf:about', '');
+        $desc->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:dc', self::NS_DC);
+        $rdf->appendChild($desc);
+
+        if ($this->title !== null) {
+            $titleEl = $doc->createElementNS(self::NS_DC, 'dc:title');
+            $alt = $doc->createElementNS(self::NS_RDF, 'rdf:Alt');
+            $li = $doc->createElementNS(self::NS_RDF, 'rdf:li');
+            $li->setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:lang', 'x-default');
+            $li->textContent = $this->title;
+            $alt->appendChild($li);
+            $titleEl->appendChild($alt);
+            $desc->appendChild($titleEl);
+        }
+
+        if ($this->creator !== null) {
+            $creatorEl = $doc->createElementNS(self::NS_DC, 'dc:creator');
+            $seq = $doc->createElementNS(self::NS_RDF, 'rdf:Seq');
+            $li = $doc->createElementNS(self::NS_RDF, 'rdf:li');
+            $li->textContent = $this->creator;
+            $seq->appendChild($li);
+            $creatorEl->appendChild($seq);
+            $desc->appendChild($creatorEl);
+        }
+
+        if ($this->description !== null) {
+            $descEl = $doc->createElementNS(self::NS_DC, 'dc:description');
+            $alt = $doc->createElementNS(self::NS_RDF, 'rdf:Alt');
+            $li = $doc->createElementNS(self::NS_RDF, 'rdf:li');
+            $li->setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:lang', 'x-default');
+            $li->textContent = $this->description;
+            $alt->appendChild($li);
+            $descEl->appendChild($alt);
+            $desc->appendChild($descEl);
+        }
+    }
+
+    private function addXmpBasic(DOMDocument $doc, DOMElement $rdf): void
+    {
+        if ($this->creatorTool === null && $this->createDate === null && $this->modifyDate === null) {
+            return;
+        }
+
+        $desc = $doc->createElementNS(self::NS_RDF, 'rdf:Description');
+        $desc->setAttributeNS(self::NS_RDF, 'rdf:about', '');
+        $desc->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xmp', self::NS_XMP);
+        $rdf->appendChild($desc);
+
+        if ($this->creatorTool !== null) {
+            $el = $doc->createElementNS(self::NS_XMP, 'xmp:CreatorTool', $this->creatorTool);
+            $desc->appendChild($el);
+        }
+        if ($this->createDate !== null) {
+            $el = $doc->createElementNS(self::NS_XMP, 'xmp:CreateDate', $this->createDate->format('Y-m-d\TH:i:sP'));
+            $desc->appendChild($el);
+        }
+        if ($this->modifyDate !== null) {
+            $el = $doc->createElementNS(self::NS_XMP, 'xmp:ModifyDate', $this->modifyDate->format('Y-m-d\TH:i:sP'));
+            $desc->appendChild($el);
+        }
+    }
+
+    private function addPdfProperties(DOMDocument $doc, DOMElement $rdf): void
+    {
+        if ($this->producer === null && $this->keywords === null) {
+            return;
+        }
+
+        $desc = $doc->createElementNS(self::NS_RDF, 'rdf:Description');
+        $desc->setAttributeNS(self::NS_RDF, 'rdf:about', '');
+        $desc->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:pdf', self::NS_PDF);
+        $rdf->appendChild($desc);
+
+        if ($this->producer !== null) {
+            $el = $doc->createElementNS(self::NS_PDF, 'pdf:Producer', $this->producer);
+            $desc->appendChild($el);
+        }
+        if ($this->keywords !== null) {
+            $el = $doc->createElementNS(self::NS_PDF, 'pdf:Keywords', $this->keywords);
+            $desc->appendChild($el);
+        }
+    }
+
+    private function addPdfaId(DOMDocument $doc, DOMElement $rdf): void
+    {
+        if ($this->pdfaPart === null && $this->pdfaConformance === null) {
+            return;
+        }
+
+        $desc = $doc->createElementNS(self::NS_RDF, 'rdf:Description');
+        $desc->setAttributeNS(self::NS_RDF, 'rdf:about', '');
+        $desc->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:pdfaid', self::NS_PDFAID);
+        $rdf->appendChild($desc);
+
+        if ($this->pdfaPart !== null) {
+            $el = $doc->createElementNS(self::NS_PDFAID, 'pdfaid:part', (string) $this->pdfaPart);
+            $desc->appendChild($el);
+        }
+        if ($this->pdfaConformance !== null) {
+            $el = $doc->createElementNS(self::NS_PDFAID, 'pdfaid:conformance', $this->pdfaConformance);
+            $desc->appendChild($el);
+        }
+    }
+
+    private function addXmpMM(DOMDocument $doc, DOMElement $rdf): void
+    {
+        if ($this->documentId === null) {
+            return;
+        }
+
+        $desc = $doc->createElementNS(self::NS_RDF, 'rdf:Description');
+        $desc->setAttributeNS(self::NS_RDF, 'rdf:about', '');
+        $desc->setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:xmpMM', self::NS_XMPMM);
+        $rdf->appendChild($desc);
+
+        $el = $doc->createElementNS(self::NS_XMPMM, 'xmpMM:DocumentID', $this->documentId);
+        $desc->appendChild($el);
+    }
+}

--- a/test/unit/MetadataStreamTest.php
+++ b/test/unit/MetadataStreamTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Horde\Pdf\MetadataStream;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MetadataStream::class)]
+class MetadataStreamTest extends TestCase
+{
+    public function testConstructionPreservesXml(): void
+    {
+        $xml = '<x:xmpmeta xmlns:x="adobe:ns:meta/"><rdf:RDF/></x:xmpmeta>';
+        $stream = new MetadataStream($xml);
+        $this->assertSame($xml, $stream->xml);
+    }
+
+    public function testEmptyXml(): void
+    {
+        $stream = new MetadataStream('');
+        $this->assertSame('', $stream->xml);
+    }
+}

--- a/test/unit/OutputIntentTest.php
+++ b/test/unit/OutputIntentTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Horde\Pdf\OutputIntent;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OutputIntent::class)]
+class OutputIntentTest extends TestCase
+{
+    public function testDefaults(): void
+    {
+        $intent = new OutputIntent();
+        $this->assertSame('GTS_PDFA1', $intent->subtype);
+        $this->assertSame('sRGB', $intent->outputConditionIdentifier);
+        $this->assertSame('http://www.color.org', $intent->registryName);
+        $this->assertSame('sRGB IEC61966-2.1', $intent->info);
+    }
+
+    public function testCustomValues(): void
+    {
+        $intent = new OutputIntent(
+            subtype: 'GTS_PDFX',
+            outputConditionIdentifier: 'FOGRA39',
+            registryName: 'http://www.color.org',
+            info: 'Coated FOGRA39',
+        );
+        $this->assertSame('GTS_PDFX', $intent->subtype);
+        $this->assertSame('FOGRA39', $intent->outputConditionIdentifier);
+        $this->assertSame('Coated FOGRA39', $intent->info);
+    }
+}

--- a/test/unit/XmpBuilderTest.php
+++ b/test/unit/XmpBuilderTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+use Horde\Pdf\MetadataStream;
+use Horde\Pdf\XmpBuilder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(XmpBuilder::class)]
+#[CoversClass(MetadataStream::class)]
+class XmpBuilderTest extends TestCase
+{
+    public function testBasicStructure(): void
+    {
+        $builder = new XmpBuilder(title: 'Test Document');
+        $stream = $builder->build();
+
+        $this->assertStringContainsString('<?xpacket begin=', $stream->xml);
+        $this->assertStringContainsString('<?xpacket end="w"?>', $stream->xml);
+        $this->assertStringContainsString('x:xmpmeta', $stream->xml);
+        $this->assertStringContainsString('rdf:RDF', $stream->xml);
+    }
+
+    public function testDublinCoreTitle(): void
+    {
+        $builder = new XmpBuilder(title: 'My PDF Title');
+        $stream = $builder->build();
+
+        $this->assertStringContainsString('dc:title', $stream->xml);
+        $this->assertStringContainsString('rdf:Alt', $stream->xml);
+        $this->assertStringContainsString('x-default', $stream->xml);
+        $this->assertStringContainsString('My PDF Title', $stream->xml);
+    }
+
+    public function testDublinCoreCreator(): void
+    {
+        $builder = new XmpBuilder(creator: 'John Doe');
+        $stream = $builder->build();
+
+        $this->assertStringContainsString('dc:creator', $stream->xml);
+        $this->assertStringContainsString('rdf:Seq', $stream->xml);
+        $this->assertStringContainsString('John Doe', $stream->xml);
+    }
+
+    public function testXmpBasicDates(): void
+    {
+        $date = new DateTimeImmutable('2026-05-24T10:30:00+02:00');
+        $builder = new XmpBuilder(
+            creatorTool: 'Horde PDF',
+            createDate: $date,
+            modifyDate: $date,
+        );
+        $stream = $builder->build();
+
+        $this->assertStringContainsString('xmp:CreatorTool', $stream->xml);
+        $this->assertStringContainsString('Horde PDF', $stream->xml);
+        $this->assertStringContainsString('xmp:CreateDate', $stream->xml);
+        $this->assertStringContainsString('2026-05-24T10:30:00+02:00', $stream->xml);
+        $this->assertStringContainsString('xmp:ModifyDate', $stream->xml);
+    }
+
+    public function testPdfProperties(): void
+    {
+        $builder = new XmpBuilder(
+            producer: 'Horde PDF Library',
+            keywords: 'test pdf metadata',
+        );
+        $stream = $builder->build();
+
+        $this->assertStringContainsString('pdf:Producer', $stream->xml);
+        $this->assertStringContainsString('Horde PDF Library', $stream->xml);
+        $this->assertStringContainsString('pdf:Keywords', $stream->xml);
+        $this->assertStringContainsString('test pdf metadata', $stream->xml);
+    }
+
+    public function testPdfaIdentification(): void
+    {
+        $builder = new XmpBuilder(pdfaPart: 1, pdfaConformance: 'B');
+        $stream = $builder->build();
+
+        $this->assertStringContainsString('pdfaid:part', $stream->xml);
+        $this->assertStringContainsString('>1<', $stream->xml);
+        $this->assertStringContainsString('pdfaid:conformance', $stream->xml);
+        $this->assertStringContainsString('>B<', $stream->xml);
+    }
+
+    public function testDocumentId(): void
+    {
+        $builder = new XmpBuilder(documentId: 'uuid:12345678-1234-1234-1234-123456789012');
+        $stream = $builder->build();
+
+        $this->assertStringContainsString('xmpMM:DocumentID', $stream->xml);
+        $this->assertStringContainsString('uuid:12345678-1234-1234-1234-123456789012', $stream->xml);
+    }
+
+    public function testXmlIsWellFormed(): void
+    {
+        $builder = new XmpBuilder(
+            title: 'Test',
+            creator: 'Author',
+            creatorTool: 'Tool',
+            createDate: new DateTimeImmutable(),
+            producer: 'Horde',
+            pdfaPart: 2,
+            pdfaConformance: 'A',
+            documentId: 'uuid:test',
+        );
+        $stream = $builder->build();
+
+        $innerXml = $this->extractXmlFromXpacket($stream->xml);
+        $doc = new DOMDocument();
+        $result = $doc->loadXML($innerXml);
+        $this->assertTrue($result, 'XMP XML should be well-formed');
+    }
+
+    public function testPaddingPresent(): void
+    {
+        $builder = new XmpBuilder(title: 'Padded');
+        $stream = $builder->build();
+
+        $packetEnd = strpos($stream->xml, '<?xpacket end=');
+        $rdfEnd = strrpos($stream->xml, '</x:xmpmeta>');
+        $padding = substr($stream->xml, $rdfEnd + strlen("</x:xmpmeta>\n"), $packetEnd - $rdfEnd - strlen("</x:xmpmeta>\n"));
+        $this->assertGreaterThan(100, strlen($padding));
+    }
+
+    private function extractXmlFromXpacket(string $xmp): string
+    {
+        $start = strpos($xmp, '<x:xmpmeta');
+        $end = strpos($xmp, '</x:xmpmeta>') + strlen('</x:xmpmeta>');
+        return substr($xmp, $start, $end - $start);
+    }
+}

--- a/test/unit/XmpOutputTest.php
+++ b/test/unit/XmpOutputTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+use Horde\Pdf\DocumentCatalog;
+use Horde\Pdf\MetadataStream;
+use Horde\Pdf\OutputIntent;
+use Horde\Pdf\PdfSerializer;
+use Horde\Pdf\PdfWriter;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PdfWriter::class)]
+#[CoversClass(PdfSerializer::class)]
+#[CoversClass(MetadataStream::class)]
+#[CoversClass(OutputIntent::class)]
+#[CoversClass(DocumentCatalog::class)]
+class XmpOutputTest extends TestCase
+{
+    public function testMetadataStreamInPdf(): void
+    {
+        $xmp = '<x:xmpmeta xmlns:x="adobe:ns:meta/"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/></x:xmpmeta>';
+        $pdf = new PdfWriter();
+        $pdf->setCompression(false);
+        $pdf->addPage();
+        $pdf->setFont('Helvetica', '', 12);
+        $pdf->text(10, 20, 'Hello');
+        $pdf->setMetadata(new MetadataStream($xmp));
+
+        $output = $pdf->getOutput();
+
+        $this->assertStringContainsString('/Type /Metadata', $output);
+        $this->assertStringContainsString('/Subtype /XML', $output);
+        $this->assertStringContainsString('/Metadata ', $output);
+        $this->assertStringContainsString($xmp, $output);
+    }
+
+    public function testOutputIntentInPdf(): void
+    {
+        $pdf = new PdfWriter();
+        $pdf->setCompression(false);
+        $pdf->addPage();
+        $pdf->setFont('Helvetica', '', 12);
+        $pdf->text(10, 20, 'Hello');
+        $pdf->addOutputIntent(new OutputIntent());
+
+        $output = $pdf->getOutput();
+
+        $this->assertStringContainsString('/Type /OutputIntent', $output);
+        $this->assertStringContainsString('/S /GTS_PDFA1', $output);
+        $this->assertStringContainsString('/OutputConditionIdentifier (sRGB)', $output);
+        $this->assertStringContainsString('/RegistryName (http://www.color.org)', $output);
+        $this->assertStringContainsString('/OutputIntents [', $output);
+    }
+
+    public function testMetadataStreamNotCompressed(): void
+    {
+        $xmp = '<?xpacket begin="' . "\xEF\xBB\xBF" . '"?><x:xmpmeta xmlns:x="adobe:ns:meta/"/><?xpacket end="w"?>';
+        $pdf = new PdfWriter();
+        $pdf->setCompression(true);
+        $pdf->addPage();
+        $pdf->setFont('Helvetica', '', 12);
+        $pdf->text(10, 20, 'Content');
+        $pdf->setMetadata(new MetadataStream($xmp));
+
+        $output = $pdf->getOutput();
+
+        $pos = strpos($output, '/Type /Metadata');
+        $this->assertNotFalse($pos);
+        $header = substr($output, $pos - 10, 80);
+        $this->assertStringNotContainsString('/FlateDecode', $header);
+    }
+
+    public function testNoMetadataNoEntry(): void
+    {
+        $pdf = new PdfWriter();
+        $pdf->setCompression(false);
+        $pdf->addPage();
+        $pdf->setFont('Helvetica', '', 12);
+        $pdf->text(10, 20, 'Plain');
+
+        $output = $pdf->getOutput();
+
+        $this->assertStringNotContainsString('/Type /Metadata', $output);
+        $this->assertStringNotContainsString('/OutputIntents', $output);
+    }
+
+    public function testMultipleOutputIntents(): void
+    {
+        $pdf = new PdfWriter();
+        $pdf->setCompression(false);
+        $pdf->addPage();
+        $pdf->setFont('Helvetica', '', 12);
+        $pdf->text(10, 20, 'Hello');
+        $pdf->addOutputIntent(new OutputIntent());
+        $pdf->addOutputIntent(new OutputIntent(subtype: 'GTS_PDFX', outputConditionIdentifier: 'FOGRA39'));
+
+        $output = $pdf->getOutput();
+
+        $this->assertStringContainsString('/S /GTS_PDFA1', $output);
+        $this->assertStringContainsString('/S /GTS_PDFX', $output);
+        $this->assertStringContainsString('/OutputConditionIdentifier (FOGRA39)', $output);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `MetadataStream` class accepting raw XMP XML payload
- Add `OutputIntent` class for PDF/A sRGB ICC profile declaration
- Add `XmpBuilder` convenience class producing well-formed XMP with Dublin Core, XMP Basic, PDF, pdfaid, and xmpMM namespaces
- Extend `DocumentCatalog` with metadata and output intents properties
- Serialize metadata as uncompressed `/Type /Metadata /Subtype /XML` stream per spec
- Serialize output intents as `/Type /OutputIntent` objects with `/OutputIntents` catalog array
- Add `horde/xml_element` as optional+dev dependency
- Fix PHPStan level 3 docblock issues and CS fixer style changes

## Test plan
- [x] MetadataStream construction (2 tests)
- [x] OutputIntent defaults and custom values (2 tests)
- [x] End-to-end PDF output with metadata stream and output intents (5 tests)
- [x] XmpBuilder produces valid XMP with correct namespaces and structure (9 tests)
- [x] Full suite regression (460 tests pass)
- [x] PHPStan level 3 clean