### PR TITLE
feat: implement Form XObjects (ISO 32000-2 §8.10) for #15

### DIFF
--- a/src/ContentStreamBuilder.php
+++ b/src/ContentStreamBuilder.php
@@ -19,14 +19,21 @@ final class ContentStreamBuilder
     /** @var array<string, ImageXObject> */
     private array $imageMap = [];
 
+    /** @var array<string, FormXObject> */
+    private array $formMap = [];
+
     private int $fontCounter = 0;
     private int $imageCounter = 0;
+    private int $formCounter = 0;
 
     /** @var array<string, string> pdfName → local name (F1, F2, ...) */
     private array $fontNameIndex = [];
 
     /** @var array<int, string> spl_object_id → local name (I1, I2, ...) */
     private array $imageNameIndex = [];
+
+    /** @var array<int, string> spl_object_id → local name (X1, X2, ...) */
+    private array $formNameIndex = [];
 
     // --- Graphics state ---
 
@@ -262,6 +269,21 @@ final class ContentStreamBuilder
         return $this;
     }
 
+    // --- Form XObjects ---
+
+    public function drawFormXObject(
+        FormXObject $form,
+        ?AffineTransform $transform = null,
+    ): self {
+        $localName = $this->registerForm($form);
+        if ($transform !== null) {
+            $this->operators[] = sprintf('q %s /%s Do Q', $transform->toPdfOperator(), $localName);
+        } else {
+            $this->operators[] = sprintf('q /%s Do Q', $localName);
+        }
+        return $this;
+    }
+
     // --- Build ---
 
     public function build(): ContentStream
@@ -290,6 +312,10 @@ final class ContentStreamBuilder
 
         foreach ($this->imageMap as $localName => $image) {
             $resources->addImage($localName, $image);
+        }
+
+        foreach ($this->formMap as $localName => $form) {
+            $resources->addForm($localName, $form);
         }
 
         $operators = implode("\n", $this->operators);
@@ -325,6 +351,21 @@ final class ContentStreamBuilder
         $localName = 'I' . (++$this->imageCounter);
         $this->imageNameIndex[$id] = $localName;
         $this->imageMap[$localName] = $image;
+
+        return $localName;
+    }
+
+    private function registerForm(FormXObject $form): string
+    {
+        $id = spl_object_id($form);
+
+        if (isset($this->formNameIndex[$id])) {
+            return $this->formNameIndex[$id];
+        }
+
+        $localName = 'X' . (++$this->formCounter);
+        $this->formNameIndex[$id] = $localName;
+        $this->formMap[$localName] = $form;
 
         return $localName;
     }

--- a/src/FormXObject.php
+++ b/src/FormXObject.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+final class FormXObject
+{
+    public function __construct(
+        public readonly Rectangle $bbox,
+        public readonly string $operators,
+        public readonly ResourceDictionary $resources,
+        public readonly ?AffineTransform $matrix = null,
+        public readonly ?TransparencyGroup $group = null,
+    ) {}
+
+    public static function create(
+        Rectangle $bbox,
+        ContentStream $content,
+        ?AffineTransform $matrix = null,
+        ?TransparencyGroup $group = null,
+    ): self {
+        return new self(
+            bbox: $bbox,
+            operators: $content->operators,
+            resources: $content->resources,
+            matrix: $matrix,
+            group: $group,
+        );
+    }
+}

--- a/src/PdfSerializer.php
+++ b/src/PdfSerializer.php
@@ -40,11 +40,13 @@ final class PdfSerializer
         $allFonts = [];
         $allImages = [];
         $allExtGStates = [];
+        $allForms = [];
         $fontObjNums = [];
         $imageObjNums = [];
         $pageResourceFontObjNums = [];
         $pageResourceImageObjNums = [];
         $pageResourceGStateObjNums = [];
+        $pageResourceFormObjNums = [];
 
         foreach ($pages as $i => $page) {
             $res = $page->resourceDictionary();
@@ -96,6 +98,14 @@ final class PdfSerializer
                 $pageGStateNums[$localName] = $allExtGStates[$key]['objNum'];
             }
             $pageResourceGStateObjNums[$i] = $pageGStateNums;
+
+            $pageFormNums = [];
+            foreach ($res->forms() as $localName => $form) {
+                $this->collectForm($form, $allForms, $allFonts, $allImages, $allExtGStates, $objectNumber);
+                $key = spl_object_id($form);
+                $pageFormNums[$localName] = $allForms[$key]['objNum'];
+            }
+            $pageResourceFormObjNums[$i] = $pageFormNums;
         }
 
         $resourceDictObjNums = [];
@@ -354,6 +364,100 @@ final class PdfSerializer
             $buffer .= "endobj\n";
         }
 
+        foreach ($allForms as $entry) {
+            $form = $entry['form'];
+            $objNum = $entry['objNum'];
+            $offsets[$objNum] = strlen($buffer);
+
+            $content = $form->operators;
+            $streamData = $this->compress ? @gzcompress($content) : false;
+            $useCompression = $streamData !== false && $this->compress;
+            if (!$useCompression) {
+                $streamData = $content;
+            }
+            if ($encHandler !== null) {
+                $streamData = $encHandler->encryptStream($streamData, $objNum, 0);
+            }
+
+            $buffer .= $objNum . " 0 obj\n";
+            $buffer .= "<</Type /XObject\n";
+            $buffer .= "/Subtype /Form\n";
+            $buffer .= "/FormType 1\n";
+            $buffer .= "/BBox " . $form->bbox->toPdfArray() . "\n";
+
+            if ($form->matrix !== null) {
+                $buffer .= sprintf(
+                    "/Matrix [%.4F %.4F %.4F %.4F %.4F %.4F]\n",
+                    $form->matrix->a,
+                    $form->matrix->b,
+                    $form->matrix->c,
+                    $form->matrix->d,
+                    $form->matrix->e,
+                    $form->matrix->f,
+                );
+            }
+
+            if ($form->group !== null) {
+                $buffer .= "/Group <</Type /Group /S /Transparency";
+                if ($form->group->colorSpace !== null) {
+                    $buffer .= " /CS /" . $form->group->colorSpace->pdfName();
+                }
+                if ($form->group->isolated) {
+                    $buffer .= " /I true";
+                }
+                if ($form->group->knockout) {
+                    $buffer .= " /K true";
+                }
+                $buffer .= ">>\n";
+            }
+
+            if (isset($entry['resourceDictObjNum'])) {
+                $buffer .= "/Resources " . $entry['resourceDictObjNum'] . " 0 R\n";
+            }
+
+            $filter = $useCompression ? '/Filter /FlateDecode ' : '';
+            $buffer .= $filter . "/Length " . strlen($streamData) . ">>\n";
+            $buffer .= "stream\n";
+            $buffer .= $streamData . "\n";
+            $buffer .= "endstream\n";
+            $buffer .= "endobj\n";
+
+            if (isset($entry['resourceDictObjNum'])) {
+                $resObjNum = $entry['resourceDictObjNum'];
+                $offsets[$resObjNum] = strlen($buffer);
+                $buffer .= $resObjNum . " 0 obj\n";
+                $buffer .= "<</ProcSet [/PDF /Text /ImageB /ImageC /ImageI]\n";
+
+                if (!empty($entry['fontObjNums'])) {
+                    $buffer .= "/Font <<";
+                    foreach ($entry['fontObjNums'] as $localName => $fObjNum) {
+                        $buffer .= " /" . $localName . " " . $fObjNum . " 0 R";
+                    }
+                    $buffer .= " >>\n";
+                }
+
+                $xObjRefs = ($entry['imageObjNums'] ?? []) + ($entry['formObjNums'] ?? []);
+                if (!empty($xObjRefs)) {
+                    $buffer .= "/XObject <<";
+                    foreach ($xObjRefs as $localName => $xObjNum) {
+                        $buffer .= " /" . $localName . " " . $xObjNum . " 0 R";
+                    }
+                    $buffer .= " >>\n";
+                }
+
+                if (!empty($entry['gsObjNums'])) {
+                    $buffer .= "/ExtGState <<";
+                    foreach ($entry['gsObjNums'] as $localName => $gsObjNum) {
+                        $buffer .= " /" . $localName . " " . $gsObjNum . " 0 R";
+                    }
+                    $buffer .= " >>\n";
+                }
+
+                $buffer .= ">>\n";
+                $buffer .= "endobj\n";
+            }
+        }
+
         foreach ($pages as $i => $page) {
             $offsets[$resourceDictObjNums[$i]] = strlen($buffer);
             $buffer .= $resourceDictObjNums[$i] . " 0 obj\n";
@@ -365,9 +469,12 @@ final class PdfSerializer
                 }
                 $buffer .= " >>\n";
             }
-            if (!empty($pageResourceImageObjNums[$i])) {
+            if (!empty($pageResourceImageObjNums[$i]) || !empty($pageResourceFormObjNums[$i])) {
                 $buffer .= "/XObject <<";
                 foreach ($pageResourceImageObjNums[$i] as $localName => $objNum) {
+                    $buffer .= " /" . $localName . " " . $objNum . " 0 R";
+                }
+                foreach ($pageResourceFormObjNums[$i] as $localName => $objNum) {
                     $buffer .= " /" . $localName . " " . $objNum . " 0 R";
                 }
                 $buffer .= " >>\n";
@@ -541,6 +648,102 @@ final class PdfSerializer
         $buffer .= "%%EOF\n";
 
         return $buffer;
+    }
+
+    /**
+     * @param array<int, mixed> $allForms
+     * @param array<string, mixed> $allFonts
+     * @param array<int, mixed> $allImages
+     * @param array<string, mixed> $allExtGStates
+     * @param array<int, bool> $visiting
+     */
+    private function collectForm(
+        FormXObject $form,
+        array &$allForms,
+        array &$allFonts,
+        array &$allImages,
+        array &$allExtGStates,
+        int &$objectNumber,
+        array $visiting = [],
+    ): void {
+        $key = spl_object_id($form);
+
+        if (isset($allForms[$key])) {
+            return;
+        }
+
+        if (isset($visiting[$key])) {
+            throw new PdfException('Circular reference detected in Form XObject nesting');
+        }
+
+        $visiting[$key] = true;
+
+        $objectNumber++;
+        $allForms[$key] = ['form' => $form, 'objNum' => $objectNumber];
+
+        $res = $form->resources;
+        $fontObjNums = [];
+        $imageObjNums = [];
+        $gsObjNums = [];
+        $formObjNums = [];
+
+        foreach ($res->fonts() as $localName => $font) {
+            $fKey = $font->pdfName();
+            if (!isset($allFonts[$fKey])) {
+                $objectNumber++;
+                $allFonts[$fKey] = ['font' => $font, 'objNum' => $objectNumber];
+                if ($font->requiresEmbedding()) {
+                    $objectNumber++;
+                    $allFonts[$fKey]['cidFontObjNum'] = $objectNumber;
+                    $objectNumber++;
+                    $allFonts[$fKey]['fontDescriptorObjNum'] = $objectNumber;
+                    $objectNumber++;
+                    $allFonts[$fKey]['fontFileObjNum'] = $objectNumber;
+                    $objectNumber++;
+                    $allFonts[$fKey]['toUnicodeObjNum'] = $objectNumber;
+                    $objectNumber++;
+                    $allFonts[$fKey]['cidToGidObjNum'] = $objectNumber;
+                }
+            }
+            $fontObjNums[$localName] = $allFonts[$fKey]['objNum'];
+        }
+
+        foreach ($res->images() as $localName => $image) {
+            $iKey = spl_object_id($image);
+            if (!isset($allImages[$iKey])) {
+                $objectNumber++;
+                $allImages[$iKey] = ['image' => $image, 'objNum' => $objectNumber];
+                if ($image->palette !== null) {
+                    $objectNumber++;
+                    $allImages[$iKey]['paletteObjNum'] = $objectNumber;
+                }
+            }
+            $imageObjNums[$localName] = $allImages[$iKey]['objNum'];
+        }
+
+        foreach ($res->extGraphicsStates() as $localName => $gs) {
+            $gKey = $gs->key();
+            if (!isset($allExtGStates[$gKey])) {
+                $objectNumber++;
+                $allExtGStates[$gKey] = ['gs' => $gs, 'objNum' => $objectNumber];
+            }
+            $gsObjNums[$localName] = $allExtGStates[$gKey]['objNum'];
+        }
+
+        foreach ($res->forms() as $localName => $nestedForm) {
+            $this->collectForm($nestedForm, $allForms, $allFonts, $allImages, $allExtGStates, $objectNumber, $visiting);
+            $nKey = spl_object_id($nestedForm);
+            $formObjNums[$localName] = $allForms[$nKey]['objNum'];
+        }
+
+        if (!$res->isEmpty()) {
+            $objectNumber++;
+            $allForms[$key]['resourceDictObjNum'] = $objectNumber;
+            $allForms[$key]['fontObjNums'] = $fontObjNums;
+            $allForms[$key]['imageObjNums'] = $imageObjNums;
+            $allForms[$key]['gsObjNums'] = $gsObjNums;
+            $allForms[$key]['formObjNums'] = $formObjNums;
+        }
     }
 
     /**

--- a/src/PdfWriter.php
+++ b/src/PdfWriter.php
@@ -74,6 +74,15 @@ final class PdfWriter
     /** @var array<int, array<string, ImageXObject>> localName → ImageXObject per page */
     private array $imageMaps = [];
 
+    /** @var array<int, int> Form counter per page */
+    private array $formCounters = [];
+
+    /** @var array<int, array<int, string>> object_id → local name per page */
+    private array $formNameMaps = [];
+
+    /** @var array<int, array<string, FormXObject>> localName → FormXObject per page */
+    private array $formMaps = [];
+
     /** @var array<int, Orientation> */
     private array $pageOrientations = [];
 
@@ -222,6 +231,9 @@ final class PdfWriter
         $this->imageCounters[$this->pageNumber] = 0;
         $this->imageNameMaps[$this->pageNumber] = [];
         $this->imageMaps[$this->pageNumber] = [];
+        $this->formCounters[$this->pageNumber] = 0;
+        $this->formNameMaps[$this->pageNumber] = [];
+        $this->formMaps[$this->pageNumber] = [];
         $this->gsCounters[$this->pageNumber] = 0;
         $this->gsKeyMaps[$this->pageNumber] = [];
         $this->gsMaps[$this->pageNumber] = [];
@@ -271,6 +283,9 @@ final class PdfWriter
             }
             foreach ($this->imageMaps[$p] as $localName => $image) {
                 $resources->addImage($localName, $image);
+            }
+            foreach ($this->formMaps[$p] as $localName => $form) {
+                $resources->addForm($localName, $form);
             }
             foreach ($this->gsMaps[$p] as $localName => $gs) {
                 $resources->addExtGState($localName, $gs);
@@ -1147,6 +1162,46 @@ final class PdfWriter
         ));
     }
 
+    // --- Form XObjects ---
+
+    public function drawForm(
+        FormXObject $form,
+        float $x,
+        float $y,
+        ?float $width = null,
+        ?float $height = null,
+    ): void {
+        $k = $this->scaleFactor;
+        $localName = $this->registerForm($form);
+
+        $formWidth = $form->bbox->width();
+        $formHeight = $form->bbox->height();
+
+        $scaleX = $width !== null ? ($width * $k / $formWidth) : 1.0;
+        $scaleY = $height !== null ? ($height * $k / $formHeight) : 1.0;
+
+        if ($width === null && $height === null) {
+            $scaleX = 1.0;
+            $scaleY = 1.0;
+        } elseif ($width !== null && $height === null) {
+            $scaleY = $scaleX;
+        } elseif ($height !== null && $width === null) {
+            $scaleX = $scaleY;
+        }
+
+        $tx = $x * $k;
+        $ty = $this->hPt - ($y * $k) - ($formHeight * $scaleY);
+
+        $this->out(sprintf(
+            'q %.4F 0 0 %.4F %.4F %.4F cm /%s Do Q',
+            $scaleX,
+            $scaleY,
+            $tx,
+            $ty,
+            $localName,
+        ));
+    }
+
     // --- Bookmarks ---
 
     /** @var array<array{title: string, level: int, page: int, y: float}> */
@@ -1353,6 +1408,23 @@ final class PdfWriter
         $localName = 'GS' . $this->gsCounters[$p];
         $this->gsKeyMaps[$p][$key] = $localName;
         $this->gsMaps[$p][$localName] = $gs;
+
+        return $localName;
+    }
+
+    private function registerForm(FormXObject $form): string
+    {
+        $p = $this->pageNumber;
+        $id = spl_object_id($form);
+
+        if (isset($this->formNameMaps[$p][$id])) {
+            return $this->formNameMaps[$p][$id];
+        }
+
+        $this->formCounters[$p]++;
+        $localName = 'X' . $this->formCounters[$p];
+        $this->formNameMaps[$p][$id] = $localName;
+        $this->formMaps[$p][$localName] = $form;
 
         return $localName;
     }

--- a/src/ResourceDictionary.php
+++ b/src/ResourceDictionary.php
@@ -15,6 +15,9 @@ final class ResourceDictionary
     /** @var array<string, ExtGState> */
     private array $extGraphicsStates = [];
 
+    /** @var array<string, FormXObject> */
+    private array $forms = [];
+
     public function addFont(string $name, Font $font): void
     {
         $this->fonts[$name] = $font;
@@ -28,6 +31,11 @@ final class ResourceDictionary
     public function addExtGState(string $name, ExtGState $gs): void
     {
         $this->extGraphicsStates[$name] = $gs;
+    }
+
+    public function addForm(string $name, FormXObject $form): void
+    {
+        $this->forms[$name] = $form;
     }
 
     /**
@@ -54,6 +62,14 @@ final class ResourceDictionary
         return $this->extGraphicsStates;
     }
 
+    /**
+     * @return array<string, FormXObject>
+     */
+    public function forms(): array
+    {
+        return $this->forms;
+    }
+
     public function merge(self $other): void
     {
         foreach ($other->fonts as $name => $font) {
@@ -73,10 +89,16 @@ final class ResourceDictionary
                 $this->extGraphicsStates[$name] = $gs;
             }
         }
+
+        foreach ($other->forms as $name => $form) {
+            if (!isset($this->forms[$name])) {
+                $this->forms[$name] = $form;
+            }
+        }
     }
 
     public function isEmpty(): bool
     {
-        return empty($this->fonts) && empty($this->images) && empty($this->extGraphicsStates);
+        return empty($this->fonts) && empty($this->images) && empty($this->extGraphicsStates) && empty($this->forms);
     }
 }

--- a/src/TransparencyGroup.php
+++ b/src/TransparencyGroup.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+final class TransparencyGroup
+{
+    public function __construct(
+        public readonly ?ColorSpace $colorSpace = null,
+        public readonly bool $isolated = false,
+        public readonly bool $knockout = false,
+    ) {}
+}

--- a/test/unit/FormXObjectBuilderTest.php
+++ b/test/unit/FormXObjectBuilderTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+use Horde\Pdf\AffineTransform;
+use Horde\Pdf\ContentStreamBuilder;
+use Horde\Pdf\FormXObject;
+use Horde\Pdf\Rectangle;
+use Horde\Pdf\ResourceDictionary;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ContentStreamBuilder::class)]
+class FormXObjectBuilderTest extends TestCase
+{
+    public function testDrawFormXObjectEmitsDoOperator(): void
+    {
+        $form = new FormXObject(
+            bbox: Rectangle::fromDimensions(100, 50),
+            operators: '',
+            resources: new ResourceDictionary(),
+        );
+
+        $builder = new ContentStreamBuilder();
+        $content = $builder->drawFormXObject($form)->build();
+
+        $this->assertStringContainsString('q /X1 Do Q', $content->operators);
+    }
+
+    public function testDrawFormXObjectWithTransform(): void
+    {
+        $form = new FormXObject(
+            bbox: Rectangle::fromDimensions(100, 50),
+            operators: '',
+            resources: new ResourceDictionary(),
+        );
+
+        $transform = AffineTransform::translate(72, 700);
+        $builder = new ContentStreamBuilder();
+        $content = $builder->drawFormXObject($form, $transform)->build();
+
+        $this->assertStringContainsString('cm /X1 Do Q', $content->operators);
+        $this->assertStringContainsString('72.0000', $content->operators);
+        $this->assertStringContainsString('700.0000', $content->operators);
+    }
+
+    public function testMultipleFormsGetUniqueNames(): void
+    {
+        $form1 = new FormXObject(
+            bbox: Rectangle::fromDimensions(100, 50),
+            operators: 'op1',
+            resources: new ResourceDictionary(),
+        );
+        $form2 = new FormXObject(
+            bbox: Rectangle::fromDimensions(200, 100),
+            operators: 'op2',
+            resources: new ResourceDictionary(),
+        );
+
+        $builder = new ContentStreamBuilder();
+        $content = $builder
+            ->drawFormXObject($form1)
+            ->drawFormXObject($form2)
+            ->build();
+
+        $this->assertStringContainsString('/X1 Do', $content->operators);
+        $this->assertStringContainsString('/X2 Do', $content->operators);
+    }
+
+    public function testSameFormInstanceReusesName(): void
+    {
+        $form = new FormXObject(
+            bbox: Rectangle::fromDimensions(100, 50),
+            operators: '',
+            resources: new ResourceDictionary(),
+        );
+
+        $builder = new ContentStreamBuilder();
+        $content = $builder
+            ->drawFormXObject($form)
+            ->drawFormXObject($form)
+            ->build();
+
+        $this->assertSame(2, substr_count($content->operators, '/X1 Do'));
+        $this->assertStringNotContainsString('/X2', $content->operators);
+    }
+
+    public function testFormRegisteredInResources(): void
+    {
+        $form = new FormXObject(
+            bbox: Rectangle::fromDimensions(100, 50),
+            operators: '',
+            resources: new ResourceDictionary(),
+        );
+
+        $builder = new ContentStreamBuilder();
+        $content = $builder->drawFormXObject($form)->build();
+
+        $forms = $content->resources->forms();
+        $this->assertCount(1, $forms);
+        $this->assertArrayHasKey('X1', $forms);
+        $this->assertSame($form, $forms['X1']);
+    }
+}

--- a/test/unit/FormXObjectSerializerTest.php
+++ b/test/unit/FormXObjectSerializerTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+use Horde\Pdf\AffineTransform;
+use Horde\Pdf\ContentStream;
+use Horde\Pdf\DeviceRgb;
+use Horde\Pdf\DocumentCatalog;
+use Horde\Pdf\EncryptionAlgorithm;
+use Horde\Pdf\EncryptionConfig;
+use Horde\Pdf\ExtGState;
+use Horde\Pdf\FormXObject;
+use Horde\Pdf\Page;
+use Horde\Pdf\PdfSerializer;
+use Horde\Pdf\Rectangle;
+use Horde\Pdf\ResourceDictionary;
+use Horde\Pdf\TransparencyGroup;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PdfSerializer::class)]
+#[CoversClass(FormXObject::class)]
+#[CoversClass(TransparencyGroup::class)]
+class FormXObjectSerializerTest extends TestCase
+{
+    private function createMinimalCatalogWithForm(FormXObject $form, string $localName = 'X1'): DocumentCatalog
+    {
+        $catalog = new DocumentCatalog();
+        $resources = new ResourceDictionary();
+        $resources->addForm($localName, $form);
+        $content = new ContentStream('q /' . $localName . ' Do Q', $resources);
+        $page = new Page(Rectangle::fromDimensions(595.28, 841.89));
+        $page->addContentStream($content);
+        $catalog->addPage($page);
+        return $catalog;
+    }
+
+    public function testSimpleFormSerialization(): void
+    {
+        $form = new FormXObject(
+            bbox: Rectangle::fromDimensions(200, 100),
+            operators: '1 0 0 rg 0 0 200 100 re f',
+            resources: new ResourceDictionary(),
+        );
+
+        $catalog = $this->createMinimalCatalogWithForm($form);
+        $serializer = new PdfSerializer(compress: false);
+        $output = $serializer->serialize($catalog);
+
+        $this->assertStringContainsString('/Type /XObject', $output);
+        $this->assertStringContainsString('/Subtype /Form', $output);
+        $this->assertStringContainsString('/FormType 1', $output);
+        $this->assertStringContainsString('/BBox [0.00 0.00 200.00 100.00]', $output);
+        $this->assertStringContainsString('1 0 0 rg 0 0 200 100 re f', $output);
+    }
+
+    public function testFormWithMatrix(): void
+    {
+        $form = new FormXObject(
+            bbox: Rectangle::fromDimensions(100, 50),
+            operators: 'q Q',
+            resources: new ResourceDictionary(),
+            matrix: AffineTransform::translate(10, 20),
+        );
+
+        $catalog = $this->createMinimalCatalogWithForm($form);
+        $serializer = new PdfSerializer(compress: false);
+        $output = $serializer->serialize($catalog);
+
+        $this->assertStringContainsString('/Matrix [1.0000 0.0000 0.0000 1.0000 10.0000 20.0000]', $output);
+    }
+
+    public function testFormWithTransparencyGroup(): void
+    {
+        $form = new FormXObject(
+            bbox: Rectangle::fromDimensions(100, 50),
+            operators: 'q Q',
+            resources: new ResourceDictionary(),
+            group: new TransparencyGroup(
+                colorSpace: new DeviceRgb(),
+                isolated: true,
+                knockout: true,
+            ),
+        );
+
+        $catalog = $this->createMinimalCatalogWithForm($form);
+        $serializer = new PdfSerializer(compress: false);
+        $output = $serializer->serialize($catalog);
+
+        $this->assertStringContainsString('/Group <<', $output);
+        $this->assertStringContainsString('/Type /Group', $output);
+        $this->assertStringContainsString('/S /Transparency', $output);
+        $this->assertStringContainsString('/CS /DeviceRGB', $output);
+        $this->assertStringContainsString('/I true', $output);
+        $this->assertStringContainsString('/K true', $output);
+    }
+
+    public function testFormWithExtGStateResources(): void
+    {
+        $resources = new ResourceDictionary();
+        $resources->addExtGState('GS1', ExtGState::alpha(0.5));
+
+        $form = new FormXObject(
+            bbox: Rectangle::fromDimensions(100, 50),
+            operators: '/GS1 gs 0 0 100 50 re f',
+            resources: $resources,
+        );
+
+        $catalog = $this->createMinimalCatalogWithForm($form);
+        $serializer = new PdfSerializer(compress: false);
+        $output = $serializer->serialize($catalog);
+
+        $this->assertStringContainsString('/Subtype /Form', $output);
+        $this->assertStringContainsString('/Resources', $output);
+        $this->assertStringContainsString('/ExtGState', $output);
+    }
+
+    public function testSameFormOnTwoPages(): void
+    {
+        $form = new FormXObject(
+            bbox: Rectangle::fromDimensions(100, 50),
+            operators: '1 0 0 rg 0 0 100 50 re f',
+            resources: new ResourceDictionary(),
+        );
+
+        $catalog = new DocumentCatalog();
+
+        $resources1 = new ResourceDictionary();
+        $resources1->addForm('X1', $form);
+        $page1 = new Page(Rectangle::fromDimensions(595.28, 841.89));
+        $page1->addContentStream(new ContentStream('q /X1 Do Q', $resources1));
+        $catalog->addPage($page1);
+
+        $resources2 = new ResourceDictionary();
+        $resources2->addForm('X1', $form);
+        $page2 = new Page(Rectangle::fromDimensions(595.28, 841.89));
+        $page2->addContentStream(new ContentStream('q /X1 Do Q', $resources2));
+        $catalog->addPage($page2);
+
+        $serializer = new PdfSerializer(compress: false);
+        $output = $serializer->serialize($catalog);
+
+        $formCount = substr_count($output, '/Subtype /Form');
+        $this->assertSame(1, $formCount);
+    }
+
+    public function testNestedForms(): void
+    {
+        $innerForm = new FormXObject(
+            bbox: Rectangle::fromDimensions(50, 25),
+            operators: '0 0 1 rg 0 0 50 25 re f',
+            resources: new ResourceDictionary(),
+        );
+
+        $outerResources = new ResourceDictionary();
+        $outerResources->addForm('X1', $innerForm);
+
+        $outerForm = new FormXObject(
+            bbox: Rectangle::fromDimensions(100, 50),
+            operators: 'q /X1 Do Q',
+            resources: $outerResources,
+        );
+
+        $catalog = $this->createMinimalCatalogWithForm($outerForm);
+        $serializer = new PdfSerializer(compress: false);
+        $output = $serializer->serialize($catalog);
+
+        $formCount = substr_count($output, '/Subtype /Form');
+        $this->assertSame(2, $formCount);
+    }
+
+    public function testFormStreamEncrypted(): void
+    {
+        $form = new FormXObject(
+            bbox: Rectangle::fromDimensions(100, 50),
+            operators: '1 0 0 rg 0 0 100 50 re f',
+            resources: new ResourceDictionary(),
+        );
+
+        $catalog = $this->createMinimalCatalogWithForm($form);
+        $catalog->setEncryption(new EncryptionConfig(
+            algorithm: EncryptionAlgorithm::AES256,
+            ownerPassword: 'owner',
+            userPassword: 'user',
+        ));
+
+        $serializer = new PdfSerializer(compress: false);
+        $output = $serializer->serialize($catalog);
+
+        $this->assertStringContainsString('/Subtype /Form', $output);
+        $this->assertStringNotContainsString('1 0 0 rg 0 0 100 50 re f', $output);
+    }
+
+    public function testFormInPageXObjectDictionary(): void
+    {
+        $form = new FormXObject(
+            bbox: Rectangle::fromDimensions(100, 50),
+            operators: '',
+            resources: new ResourceDictionary(),
+        );
+
+        $catalog = $this->createMinimalCatalogWithForm($form);
+        $serializer = new PdfSerializer(compress: false);
+        $output = $serializer->serialize($catalog);
+
+        $this->assertMatchesRegularExpression('/\/XObject <<[^>]*\/X1 \d+ 0 R/', $output);
+    }
+}

--- a/test/unit/FormXObjectTest.php
+++ b/test/unit/FormXObjectTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use Horde\Pdf\AffineTransform;
+use Horde\Pdf\ContentStream;
+use Horde\Pdf\ContentStreamBuilder;
+use Horde\Pdf\FormXObject;
+use Horde\Pdf\Rectangle;
+use Horde\Pdf\ResourceDictionary;
+use Horde\Pdf\TransparencyGroup;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FormXObject::class)]
+class FormXObjectTest extends TestCase
+{
+    public function testConstructor(): void
+    {
+        $bbox = Rectangle::fromDimensions(200, 100);
+        $resources = new ResourceDictionary();
+        $form = new FormXObject(
+            bbox: $bbox,
+            operators: 'q 1 0 0 rg 0 0 200 100 re f Q',
+            resources: $resources,
+        );
+
+        $this->assertSame($bbox, $form->bbox);
+        $this->assertSame('q 1 0 0 rg 0 0 200 100 re f Q', $form->operators);
+        $this->assertSame($resources, $form->resources);
+        $this->assertNull($form->matrix);
+        $this->assertNull($form->group);
+    }
+
+    public function testConstructorWithOptionalParams(): void
+    {
+        $bbox = Rectangle::fromDimensions(100, 50);
+        $resources = new ResourceDictionary();
+        $matrix = AffineTransform::translate(10, 20);
+        $group = new TransparencyGroup(isolated: true);
+
+        $form = new FormXObject(
+            bbox: $bbox,
+            operators: 'BT /F1 12 Tf (Hello) Tj ET',
+            resources: $resources,
+            matrix: $matrix,
+            group: $group,
+        );
+
+        $this->assertSame($matrix, $form->matrix);
+        $this->assertSame($group, $form->group);
+    }
+
+    public function testCreateFactory(): void
+    {
+        $builder = new ContentStreamBuilder();
+        $content = $builder
+            ->save()
+            ->rect(0, 0, 100, 50)
+            ->fill()
+            ->restore()
+            ->build();
+
+        $bbox = Rectangle::fromDimensions(100, 50);
+        $form = FormXObject::create($bbox, $content);
+
+        $this->assertSame($content->operators, $form->operators);
+        $this->assertSame($content->resources, $form->resources);
+        $this->assertNull($form->matrix);
+        $this->assertNull($form->group);
+    }
+
+    public function testCreateFactoryWithMatrix(): void
+    {
+        $content = new ContentStream('', new ResourceDictionary());
+        $bbox = Rectangle::fromDimensions(50, 50);
+        $matrix = AffineTransform::scale(2.0);
+
+        $form = FormXObject::create($bbox, $content, matrix: $matrix);
+        $this->assertSame($matrix, $form->matrix);
+    }
+
+    public function testCreateFactoryWithGroup(): void
+    {
+        $content = new ContentStream('', new ResourceDictionary());
+        $bbox = Rectangle::fromDimensions(50, 50);
+        $group = new TransparencyGroup(isolated: true, knockout: true);
+
+        $form = FormXObject::create($bbox, $content, group: $group);
+        $this->assertSame($group, $form->group);
+    }
+}

--- a/test/unit/FormXObjectWriterTest.php
+++ b/test/unit/FormXObjectWriterTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+use Horde\Pdf\FormXObject;
+use Horde\Pdf\PdfWriter;
+use Horde\Pdf\Rectangle;
+use Horde\Pdf\ResourceDictionary;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PdfWriter::class)]
+class FormXObjectWriterTest extends TestCase
+{
+    public function testDrawFormProducesValidPdf(): void
+    {
+        $form = new FormXObject(
+            bbox: Rectangle::fromDimensions(200, 100),
+            operators: '1 0 0 rg 0 0 200 100 re f',
+            resources: new ResourceDictionary(),
+        );
+
+        $writer = new PdfWriter(compress: false);
+        $writer->addPage();
+        $writer->drawForm($form, 10, 10);
+
+        $output = $writer->getOutput();
+
+        $this->assertStringStartsWith('%PDF-', $output);
+        $this->assertStringContainsString('/Subtype /Form', $output);
+        $this->assertStringContainsString('/X1 Do', $output);
+    }
+
+    public function testDrawFormWithDimensions(): void
+    {
+        $form = new FormXObject(
+            bbox: Rectangle::fromDimensions(100, 50),
+            operators: '0 1 0 rg 0 0 100 50 re f',
+            resources: new ResourceDictionary(),
+        );
+
+        $writer = new PdfWriter(compress: false);
+        $writer->addPage();
+        $writer->drawForm($form, 20, 30, width: 200, height: 100);
+
+        $output = $writer->getOutput();
+
+        $this->assertStringContainsString('/X1 Do', $output);
+        $this->assertStringContainsString('/Subtype /Form', $output);
+    }
+
+    public function testSameFormOnMultiplePages(): void
+    {
+        $form = new FormXObject(
+            bbox: Rectangle::fromDimensions(100, 50),
+            operators: '1 0 0 rg 0 0 100 50 re f',
+            resources: new ResourceDictionary(),
+        );
+
+        $writer = new PdfWriter(compress: false);
+        $writer->addPage();
+        $writer->drawForm($form, 10, 10);
+        $writer->addPage();
+        $writer->drawForm($form, 10, 10);
+
+        $output = $writer->getOutput();
+
+        $formCount = substr_count($output, '/Subtype /Form');
+        $this->assertSame(1, $formCount);
+
+        $doCount = substr_count($output, '/X1 Do');
+        $this->assertSame(2, $doCount);
+    }
+
+    public function testDrawFormWidthOnlyScalesProportionally(): void
+    {
+        $form = new FormXObject(
+            bbox: Rectangle::fromDimensions(100, 50),
+            operators: '',
+            resources: new ResourceDictionary(),
+        );
+
+        $writer = new PdfWriter(compress: false);
+        $writer->addPage();
+        $writer->drawForm($form, 0, 0, width: 200);
+
+        $output = $writer->getOutput();
+
+        $this->assertStringContainsString('/X1 Do', $output);
+    }
+}

--- a/test/unit/TransparencyGroupTest.php
+++ b/test/unit/TransparencyGroupTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Horde\Pdf\ColorSpace;
+use Horde\Pdf\DeviceRgb;
+use Horde\Pdf\TransparencyGroup;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TransparencyGroup::class)]
+class TransparencyGroupTest extends TestCase
+{
+    public function testDefaults(): void
+    {
+        $group = new TransparencyGroup();
+        $this->assertNull($group->colorSpace);
+        $this->assertFalse($group->isolated);
+        $this->assertFalse($group->knockout);
+    }
+
+    public function testWithAllProperties(): void
+    {
+        $cs = new DeviceRgb();
+        $group = new TransparencyGroup(
+            colorSpace: $cs,
+            isolated: true,
+            knockout: true,
+        );
+        $this->assertSame($cs, $group->colorSpace);
+        $this->assertTrue($group->isolated);
+        $this->assertTrue($group->knockout);
+    }
+
+    public function testIsolatedOnly(): void
+    {
+        $group = new TransparencyGroup(isolated: true);
+        $this->assertNull($group->colorSpace);
+        $this->assertTrue($group->isolated);
+        $this->assertFalse($group->knockout);
+    }
+}


### PR DESCRIPTION
## Summary

- Implement Form XObjects per ISO 32000-2 §8.10 (reusable content containers via `Do` operator)
- Supports `/BBox`, `/Matrix`, `/Group` (transparency), self-contained `/Resources`, nesting, deduplication, compression, and encryption
- New classes: `FormXObject`, `TransparencyGroup`
- Extended: `ResourceDictionary`, `ContentStreamBuilder`, `PdfSerializer`, `PdfWriter`

## Test plan

- [x] 25 new tests covering DTO, builder, serializer, and writer integration
- [x] Full suite passes (503 tests)

Refs #15