### PR TITLE
feat: tagged PDF / accessibility (ISO 32000-2 §14.8) #15

### DIFF
--- a/src/ContentStreamBuilder.php
+++ b/src/ContentStreamBuilder.php
@@ -11,6 +11,7 @@ final class ContentStreamBuilder
 
     private bool $inTextObject = false;
     private int $graphicsStateDepth = 0;
+    private int $markedContentDepth = 0;
 
     /** @var array<string, Font> */
     private array $fontMap = [];
@@ -229,6 +230,32 @@ final class ContentStreamBuilder
         return $this;
     }
 
+    // --- Marked Content ---
+
+    public function beginMarkedContent(string $tag, int $mcid): self
+    {
+        $this->operators[] = sprintf('/%s <</MCID %d>> BDC', $tag, $mcid);
+        $this->markedContentDepth++;
+        return $this;
+    }
+
+    public function beginMarkedContentSimple(string $tag): self
+    {
+        $this->operators[] = sprintf('/%s BMC', $tag);
+        $this->markedContentDepth++;
+        return $this;
+    }
+
+    public function endMarkedContent(): self
+    {
+        if ($this->markedContentDepth <= 0) {
+            throw new PdfException('Unbalanced endMarkedContent: no matching beginMarkedContent');
+        }
+        $this->operators[] = 'EMC';
+        $this->markedContentDepth--;
+        return $this;
+    }
+
     // --- Build ---
 
     public function build(): ContentStream
@@ -240,6 +267,12 @@ final class ContentStreamBuilder
         if ($this->graphicsStateDepth !== 0) {
             throw new PdfException(
                 sprintf('Unbalanced graphics state: %d save(s) without matching restore', $this->graphicsStateDepth)
+            );
+        }
+
+        if ($this->markedContentDepth !== 0) {
+            throw new PdfException(
+                sprintf('Unbalanced marked content: %d open sequence(s) at build time', $this->markedContentDepth)
             );
         }
 

--- a/src/DocumentCatalog.php
+++ b/src/DocumentCatalog.php
@@ -14,6 +14,8 @@ final class DocumentCatalog
     /** @var array<OutputIntent> */
     private array $outputIntents = [];
     private ?EncryptionConfig $encryption = null;
+    private bool $marked = false;
+    private ?StructureTree $structureTree = null;
 
     public function __construct(
         public readonly PdfVersion $version = PdfVersion::V1_7,
@@ -92,5 +94,26 @@ final class DocumentCatalog
     public function encryption(): ?EncryptionConfig
     {
         return $this->encryption;
+    }
+
+    public function setMarked(bool $marked = true): void
+    {
+        $this->marked = $marked;
+    }
+
+    public function isMarked(): bool
+    {
+        return $this->marked;
+    }
+
+    public function setStructureTree(StructureTree $tree): void
+    {
+        $this->structureTree = $tree;
+        $this->marked = true;
+    }
+
+    public function structureTree(): ?StructureTree
+    {
+        return $this->structureTree;
     }
 }

--- a/src/Page.php
+++ b/src/Page.php
@@ -14,6 +14,8 @@ final class Page
     /** @var array<int, Annotation> */
     private array $annotations = [];
 
+    private ?int $structParents = null;
+
     public function __construct(
         public readonly Rectangle $mediaBox,
     ) {
@@ -50,5 +52,15 @@ final class Page
     public function annotations(): array
     {
         return $this->annotations;
+    }
+
+    public function setStructParents(int $value): void
+    {
+        $this->structParents = $value;
+    }
+
+    public function structParents(): ?int
+    {
+        return $this->structParents;
     }
 }

--- a/src/PdfSerializer.php
+++ b/src/PdfSerializer.php
@@ -140,6 +140,37 @@ final class PdfSerializer
             $encryptObjNum = $objectNumber;
         }
 
+        $structTreeRootObjNum = 0;
+        $markInfoObjNum = 0;
+        $parentTreeObjNum = 0;
+        /** @var SplObjectStorage<StructureElement, int> */
+        $structElemObjNums = new SplObjectStorage();
+        /** @var SplObjectStorage<Page, int> */
+        $pageStructParentsMap = new SplObjectStorage();
+        $structureTree = $catalog->structureTree();
+
+        if ($structureTree !== null && !$structureTree->isEmpty()) {
+            foreach ($pages as $i => $page) {
+                $page->setStructParents($i);
+                $pageStructParentsMap[$page] = $i;
+            }
+
+            $objectNumber++;
+            $structTreeRootObjNum = $objectNumber;
+
+            $objectNumber++;
+            $markInfoObjNum = $objectNumber;
+
+            $objectNumber++;
+            $parentTreeObjNum = $objectNumber;
+
+            $this->allocateStructElemObjNums(
+                $structureTree->rootElements(),
+                $objectNumber,
+                $structElemObjNums,
+            );
+        }
+
         $totalObjects = $objectNumber;
 
         // Generate file ID and encryption handler
@@ -180,6 +211,9 @@ final class PdfSerializer
                 $buffer .= "]\n";
             }
 
+            if ($page->structParents() !== null) {
+                $buffer .= "/StructParents " . $page->structParents() . "\n";
+            }
             $buffer .= "/Contents " . $streamObjNums[$i] . " 0 R>>\n";
             $buffer .= "endobj\n";
 
@@ -407,6 +441,12 @@ final class PdfSerializer
             }
             $buffer .= "]\n";
         }
+        if ($markInfoObjNum > 0) {
+            $buffer .= "/MarkInfo " . $markInfoObjNum . " 0 R\n";
+        }
+        if ($structTreeRootObjNum > 0) {
+            $buffer .= "/StructTreeRoot " . $structTreeRootObjNum . " 0 R\n";
+        }
         $this->writeCatalogViewerPrefs($catalog, $buffer, $pages, $pageObjNums);
         $buffer .= ">>\n";
         $buffer .= "endobj\n";
@@ -460,6 +500,22 @@ final class PdfSerializer
             $buffer .= "/P " . $encryption->permissionFlags() . "\n";
             $buffer .= ">>\n";
             $buffer .= "endobj\n";
+        }
+
+        if ($structTreeRootObjNum > 0 && $structureTree !== null) {
+            $this->serializeStructureTree(
+                $buffer,
+                $offsets,
+                $structureTree,
+                $structTreeRootObjNum,
+                $markInfoObjNum,
+                $parentTreeObjNum,
+                $structElemObjNums,
+                $pageStructParentsMap,
+                $objectMap,
+                count($pages),
+                $encHandler,
+            );
         }
 
         $xrefOffset = strlen($buffer);
@@ -826,5 +882,160 @@ final class PdfSerializer
         }
         $encrypted = $handler->encryptString($s, $objNum, 0);
         return '<' . bin2hex($encrypted) . '>';
+    }
+
+    /**
+     * @param array<int, StructureElement> $elements
+     * @param SplObjectStorage<StructureElement, int> $structElemObjNums
+     */
+    private function allocateStructElemObjNums(
+        array $elements,
+        int &$objectNumber,
+        SplObjectStorage $structElemObjNums,
+    ): void {
+        foreach ($elements as $element) {
+            $objectNumber++;
+            $structElemObjNums[$element] = $objectNumber;
+            if (!empty($element->children())) {
+                $this->allocateStructElemObjNums($element->children(), $objectNumber, $structElemObjNums);
+            }
+        }
+    }
+
+    /**
+     * @param SplObjectStorage<StructureElement, int> $structElemObjNums
+     * @param SplObjectStorage<Page, int> $pageStructParentsMap
+     * @param SplObjectStorage<object, int> $objectMap
+     */
+    private function serializeStructureTree(
+        string &$buffer,
+        array &$offsets,
+        StructureTree $tree,
+        int $structTreeRootObjNum,
+        int $markInfoObjNum,
+        int $parentTreeObjNum,
+        SplObjectStorage $structElemObjNums,
+        SplObjectStorage $pageStructParentsMap,
+        SplObjectStorage $objectMap,
+        int $pageCount,
+        ?EncryptionHandler $encHandler,
+    ): void {
+        // MarkInfo
+        $offsets[$markInfoObjNum] = strlen($buffer);
+        $buffer .= $markInfoObjNum . " 0 obj\n";
+        $buffer .= "<</Marked true>>\n";
+        $buffer .= "endobj\n";
+
+        // StructTreeRoot
+        $offsets[$structTreeRootObjNum] = strlen($buffer);
+        $buffer .= $structTreeRootObjNum . " 0 obj\n";
+        $buffer .= "<</Type /StructTreeRoot\n";
+        $rootElements = $tree->rootElements();
+        $buffer .= "/K [";
+        foreach ($rootElements as $elem) {
+            $buffer .= $structElemObjNums[$elem] . " 0 R ";
+        }
+        $buffer .= "]\n";
+        $buffer .= "/ParentTree " . $parentTreeObjNum . " 0 R\n";
+        $buffer .= "/ParentTreeNextKey " . $pageCount . "\n";
+        $buffer .= ">>\n";
+        $buffer .= "endobj\n";
+
+        // StructElem objects
+        $this->serializeStructElements(
+            $buffer,
+            $offsets,
+            $rootElements,
+            $structTreeRootObjNum,
+            $structElemObjNums,
+            $objectMap,
+            $encHandler,
+        );
+
+        // ParentTree
+        $parentTree = $tree->buildParentTree($pageStructParentsMap);
+        $offsets[$parentTreeObjNum] = strlen($buffer);
+        $buffer .= $parentTreeObjNum . " 0 obj\n";
+        $buffer .= "<</Nums [\n";
+        for ($i = 0; $i < $pageCount; $i++) {
+            $buffer .= $i . " [";
+            if (isset($parentTree[$i])) {
+                ksort($parentTree[$i]);
+                foreach ($parentTree[$i] as $elem) {
+                    $buffer .= $structElemObjNums[$elem] . " 0 R ";
+                }
+            }
+            $buffer .= "]\n";
+        }
+        $buffer .= "]>>\n";
+        $buffer .= "endobj\n";
+    }
+
+    /**
+     * @param array<int, StructureElement> $elements
+     * @param SplObjectStorage<StructureElement, int> $structElemObjNums
+     * @param SplObjectStorage<object, int> $objectMap
+     */
+    private function serializeStructElements(
+        string &$buffer,
+        array &$offsets,
+        array $elements,
+        int $parentObjNum,
+        SplObjectStorage $structElemObjNums,
+        SplObjectStorage $objectMap,
+        ?EncryptionHandler $encHandler,
+    ): void {
+        foreach ($elements as $element) {
+            $objNum = $structElemObjNums[$element];
+            $offsets[$objNum] = strlen($buffer);
+            $buffer .= $objNum . " 0 obj\n";
+            $buffer .= "<</Type /StructElem\n";
+            $buffer .= "/S /" . $element->type->value . "\n";
+            $buffer .= "/P " . $parentObjNum . " 0 R\n";
+
+            $children = $element->children();
+            $mcids = $element->markedContentIds();
+
+            if (!empty($children) || !empty($mcids)) {
+                $buffer .= "/K [";
+                foreach ($mcids as $mc) {
+                    $buffer .= $mc['mcid'] . " ";
+                }
+                foreach ($children as $child) {
+                    $buffer .= $structElemObjNums[$child] . " 0 R ";
+                }
+                $buffer .= "]\n";
+            }
+
+            if (!empty($mcids)) {
+                $pageObjNum = $objectMap[$mcids[0]['page']];
+                $buffer .= "/Pg " . $pageObjNum . " 0 R\n";
+            }
+
+            if ($element->altText !== null) {
+                $buffer .= "/Alt " . $this->encTextString($element->altText, $objNum, $encHandler) . "\n";
+            }
+            if ($element->actualText !== null) {
+                $buffer .= "/ActualText " . $this->encTextString($element->actualText, $objNum, $encHandler) . "\n";
+            }
+            if ($element->lang !== null) {
+                $buffer .= "/Lang " . $this->encTextString($element->lang, $objNum, $encHandler) . "\n";
+            }
+
+            $buffer .= ">>\n";
+            $buffer .= "endobj\n";
+
+            if (!empty($children)) {
+                $this->serializeStructElements(
+                    $buffer,
+                    $offsets,
+                    $children,
+                    $objNum,
+                    $structElemObjNums,
+                    $objectMap,
+                    $encHandler,
+                );
+            }
+        }
     }
 }

--- a/src/PdfWriter.php
+++ b/src/PdfWriter.php
@@ -110,6 +110,18 @@ final class PdfWriter
     /** @var array<string, DeferredFont> PostScript name → DeferredFont instance */
     private array $deferredFonts = [];
 
+    /** @var array<int, int> Per-page MCID counter */
+    private array $mcidCounters = [];
+
+    /** @var array<int, StructureElement> Stack of open structure elements */
+    private array $structureStack = [];
+
+    private ?StructureTree $structureTree = null;
+    private ?StructureElement $documentElement = null;
+
+    /** @var array<int, array{element: StructureElement, mcid: int, pageNum: int}> */
+    private array $deferredMcidBindings = [];
+
     public function __construct(
         private readonly WriterOptions $options = new WriterOptions(),
         ?HeaderFooterHandler $headerFooter = null,
@@ -212,6 +224,7 @@ final class PdfWriter
         $this->gsCounters[$this->pageNumber] = 0;
         $this->gsKeyMaps[$this->pageNumber] = [];
         $this->gsMaps[$this->pageNumber] = [];
+        $this->mcidCounters[$this->pageNumber] = 0;
         $this->state = DocumentState::PageOpen;
 
         $this->x = $this->leftMargin;
@@ -290,6 +303,17 @@ final class PdfWriter
         }
         if ($this->encryption !== null) {
             $catalog->setEncryption($this->encryption);
+        }
+
+        if ($this->structureTree !== null) {
+            if (!empty($this->structureStack)) {
+                throw new PdfException('Unclosed structure elements at output time');
+            }
+            foreach ($this->deferredMcidBindings as $binding) {
+                $page = $pageObjects[$binding['pageNum']];
+                $binding['element']->addMarkedContent($binding['mcid'], $page);
+            }
+            $catalog->setStructureTree($this->structureTree);
         }
 
         return (new PdfSerializer(compress: $this->compress))->serialize($catalog);
@@ -1214,6 +1238,44 @@ final class PdfWriter
     public function setCompression(bool $compress): void
     {
         $this->compress = $compress;
+    }
+
+    // --- Structure / Tagged PDF ---
+
+    public function beginStructure(StructureType $type, ?string $altText = null, ?string $lang = null): void
+    {
+        if ($this->structureTree === null) {
+            $this->structureTree = new StructureTree();
+            $this->documentElement = new StructureElement(StructureType::Document);
+            $this->structureTree->add($this->documentElement);
+        }
+
+        $element = new StructureElement($type, altText: $altText, lang: $lang);
+
+        $parent = !empty($this->structureStack)
+            ? $this->structureStack[count($this->structureStack) - 1]
+            : $this->documentElement;
+        $parent->addChild($element);
+
+        $mcid = $this->mcidCounters[$this->pageNumber]++;
+        $this->deferredMcidBindings[] = [
+            'element' => $element,
+            'mcid' => $mcid,
+            'pageNum' => $this->pageNumber,
+        ];
+
+        $this->out(sprintf('/%s <</MCID %d>> BDC', $type->value, $mcid));
+        $this->structureStack[] = $element;
+    }
+
+    public function endStructure(): void
+    {
+        if (empty($this->structureStack)) {
+            throw new PdfException('endStructure called without matching beginStructure');
+        }
+
+        array_pop($this->structureStack);
+        $this->out('EMC');
     }
 
     // --- Private helpers ---

--- a/src/StructureElement.php
+++ b/src/StructureElement.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+final class StructureElement
+{
+    /** @var array<int, self> */
+    private array $childElements = [];
+
+    /** @var array<int, array{mcid: int, page: Page}> */
+    private array $markedContentIds = [];
+
+    public function __construct(
+        public readonly StructureType $type,
+        public readonly ?string $altText = null,
+        public readonly ?string $actualText = null,
+        public readonly ?string $lang = null,
+    ) {}
+
+    public function addChild(self $child): void
+    {
+        $this->childElements[] = $child;
+    }
+
+    public function addMarkedContent(int $mcid, Page $page): void
+    {
+        $this->markedContentIds[] = ['mcid' => $mcid, 'page' => $page];
+    }
+
+    /**
+     * @return array<int, self>
+     */
+    public function children(): array
+    {
+        return $this->childElements;
+    }
+
+    /**
+     * @return array<int, array{mcid: int, page: Page}>
+     */
+    public function markedContentIds(): array
+    {
+        return $this->markedContentIds;
+    }
+
+    public function hasChildren(): bool
+    {
+        return !empty($this->childElements) || !empty($this->markedContentIds);
+    }
+}

--- a/src/StructureTree.php
+++ b/src/StructureTree.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+use SplObjectStorage;
+
+final class StructureTree
+{
+    /** @var array<int, StructureElement> */
+    private array $rootElements = [];
+
+    public function add(StructureElement $element): void
+    {
+        $this->rootElements[] = $element;
+    }
+
+    /**
+     * @return array<int, StructureElement>
+     */
+    public function rootElements(): array
+    {
+        return $this->rootElements;
+    }
+
+    public function isEmpty(): bool
+    {
+        return empty($this->rootElements);
+    }
+
+    /**
+     * @param SplObjectStorage<Page, int> $pageStructParentsMap
+     * @return array<int, array<int, StructureElement>>
+     */
+    public function buildParentTree(SplObjectStorage $pageStructParentsMap): array
+    {
+        $parentTree = [];
+        $this->walkForParentTree($this->rootElements, $pageStructParentsMap, $parentTree);
+        return $parentTree;
+    }
+
+    /**
+     * @param array<int, StructureElement> $elements
+     * @param SplObjectStorage<Page, int> $pageStructParentsMap
+     * @param array<int, array<int, StructureElement>> $parentTree
+     */
+    private function walkForParentTree(
+        array $elements,
+        SplObjectStorage $pageStructParentsMap,
+        array &$parentTree,
+    ): void {
+        foreach ($elements as $element) {
+            foreach ($element->markedContentIds() as $mc) {
+                $structParentsKey = $pageStructParentsMap[$mc['page']];
+                $parentTree[$structParentsKey][$mc['mcid']] = $element;
+            }
+            $this->walkForParentTree($element->children(), $pageStructParentsMap, $parentTree);
+        }
+    }
+}

--- a/src/StructureType.php
+++ b/src/StructureType.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+enum StructureType: string
+{
+    case Document = 'Document';
+    case Part = 'Part';
+    case Sect = 'Sect';
+    case Div = 'Div';
+    case P = 'P';
+    case H1 = 'H1';
+    case H2 = 'H2';
+    case H3 = 'H3';
+    case H4 = 'H4';
+    case H5 = 'H5';
+    case H6 = 'H6';
+    case Span = 'Span';
+    case Link = 'Link';
+    case Figure = 'Figure';
+    case Table = 'Table';
+    case TR = 'TR';
+    case TH = 'TH';
+    case TD = 'TD';
+    case L = 'L';
+    case LI = 'LI';
+    case Lbl = 'Lbl';
+    case LBody = 'LBody';
+    case Caption = 'Caption';
+    case Annot = 'Annot';
+    case BlockQuote = 'BlockQuote';
+    case Code = 'Code';
+}

--- a/test/unit/StructureElementTest.php
+++ b/test/unit/StructureElementTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Horde\Pdf\Page;
+use Horde\Pdf\Rectangle;
+use Horde\Pdf\StructureElement;
+use Horde\Pdf\StructureType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(StructureElement::class)]
+class StructureElementTest extends TestCase
+{
+    public function testConstruction(): void
+    {
+        $elem = new StructureElement(StructureType::P, altText: 'A paragraph', lang: 'en');
+        $this->assertSame(StructureType::P, $elem->type);
+        $this->assertSame('A paragraph', $elem->altText);
+        $this->assertSame('en', $elem->lang);
+        $this->assertNull($elem->actualText);
+    }
+
+    public function testAddChild(): void
+    {
+        $parent = new StructureElement(StructureType::Document);
+        $child = new StructureElement(StructureType::P);
+        $parent->addChild($child);
+
+        $this->assertCount(1, $parent->children());
+        $this->assertSame($child, $parent->children()[0]);
+    }
+
+    public function testAddMarkedContent(): void
+    {
+        $elem = new StructureElement(StructureType::Span);
+        $page = new Page(Rectangle::fromDimensions(612, 792));
+        $elem->addMarkedContent(0, $page);
+
+        $mcids = $elem->markedContentIds();
+        $this->assertCount(1, $mcids);
+        $this->assertSame(0, $mcids[0]['mcid']);
+        $this->assertSame($page, $mcids[0]['page']);
+    }
+
+    public function testHasChildrenWithElements(): void
+    {
+        $parent = new StructureElement(StructureType::Div);
+        $this->assertFalse($parent->hasChildren());
+
+        $parent->addChild(new StructureElement(StructureType::P));
+        $this->assertTrue($parent->hasChildren());
+    }
+
+    public function testHasChildrenWithMarkedContent(): void
+    {
+        $elem = new StructureElement(StructureType::P);
+        $this->assertFalse($elem->hasChildren());
+
+        $elem->addMarkedContent(0, new Page(Rectangle::fromDimensions(612, 792)));
+        $this->assertTrue($elem->hasChildren());
+    }
+}

--- a/test/unit/StructureTreeTest.php
+++ b/test/unit/StructureTreeTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Horde\Pdf\Page;
+use Horde\Pdf\Rectangle;
+use Horde\Pdf\StructureElement;
+use Horde\Pdf\StructureTree;
+use Horde\Pdf\StructureType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+#[CoversClass(StructureTree::class)]
+class StructureTreeTest extends TestCase
+{
+    public function testAddAndRetrieve(): void
+    {
+        $tree = new StructureTree();
+        $elem = new StructureElement(StructureType::Document);
+        $tree->add($elem);
+
+        $this->assertCount(1, $tree->rootElements());
+        $this->assertSame($elem, $tree->rootElements()[0]);
+    }
+
+    public function testIsEmpty(): void
+    {
+        $tree = new StructureTree();
+        $this->assertTrue($tree->isEmpty());
+
+        $tree->add(new StructureElement(StructureType::Document));
+        $this->assertFalse($tree->isEmpty());
+    }
+
+    public function testBuildParentTree(): void
+    {
+        $page = new Page(Rectangle::fromDimensions(612, 792));
+
+        $doc = new StructureElement(StructureType::Document);
+        $p1 = new StructureElement(StructureType::P);
+        $p2 = new StructureElement(StructureType::P);
+
+        $p1->addMarkedContent(0, $page);
+        $p2->addMarkedContent(1, $page);
+        $doc->addChild($p1);
+        $doc->addChild($p2);
+
+        $tree = new StructureTree();
+        $tree->add($doc);
+
+        /** @var \SplObjectStorage<Page, int> */
+        $pageMap = new \SplObjectStorage();
+        $pageMap[$page] = 0;
+
+        $parentTree = $tree->buildParentTree($pageMap);
+
+        $this->assertArrayHasKey(0, $parentTree);
+        $this->assertSame($p1, $parentTree[0][0]);
+        $this->assertSame($p2, $parentTree[0][1]);
+    }
+}

--- a/test/unit/StructureTypeTest.php
+++ b/test/unit/StructureTypeTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Horde\Pdf\StructureType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(StructureType::class)]
+class StructureTypeTest extends TestCase
+{
+    public function testEnumValuesMatchPdfNames(): void
+    {
+        $this->assertSame('Document', StructureType::Document->value);
+        $this->assertSame('P', StructureType::P->value);
+        $this->assertSame('H1', StructureType::H1->value);
+        $this->assertSame('Table', StructureType::Table->value);
+        $this->assertSame('Figure', StructureType::Figure->value);
+        $this->assertSame('BlockQuote', StructureType::BlockQuote->value);
+    }
+
+    public function testCaseCount(): void
+    {
+        $cases = StructureType::cases();
+        $this->assertGreaterThanOrEqual(25, count($cases));
+    }
+}

--- a/test/unit/TaggedContentStreamTest.php
+++ b/test/unit/TaggedContentStreamTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use Horde\Pdf\ContentStreamBuilder;
+use Horde\Pdf\CoreFont;
+use Horde\Pdf\PdfException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ContentStreamBuilder::class)]
+class TaggedContentStreamTest extends TestCase
+{
+    public function testBeginMarkedContentEmitsBdc(): void
+    {
+        $stream = (new ContentStreamBuilder())
+            ->beginMarkedContent('P', 0)
+            ->endMarkedContent()
+            ->build();
+
+        $this->assertStringContainsString('/P <</MCID 0>> BDC', $stream->operators);
+        $this->assertStringContainsString('EMC', $stream->operators);
+    }
+
+    public function testBeginMarkedContentSimpleEmitsBmc(): void
+    {
+        $stream = (new ContentStreamBuilder())
+            ->beginMarkedContentSimple('Artifact')
+            ->endMarkedContent()
+            ->build();
+
+        $this->assertStringContainsString('/Artifact BMC', $stream->operators);
+        $this->assertStringContainsString('EMC', $stream->operators);
+    }
+
+    public function testUnbalancedEndThrows(): void
+    {
+        $this->expectException(PdfException::class);
+
+        (new ContentStreamBuilder())->endMarkedContent();
+    }
+
+    public function testUnclosedMarkedContentThrowsOnBuild(): void
+    {
+        $this->expectException(PdfException::class);
+
+        (new ContentStreamBuilder())
+            ->beginMarkedContent('Span', 1)
+            ->build();
+    }
+
+    public function testNestedMarkedContent(): void
+    {
+        $stream = (new ContentStreamBuilder())
+            ->beginMarkedContent('Div', 0)
+            ->beginMarkedContent('P', 1)
+            ->endMarkedContent()
+            ->endMarkedContent()
+            ->build();
+
+        $this->assertStringContainsString('/Div <</MCID 0>> BDC', $stream->operators);
+        $this->assertStringContainsString('/P <</MCID 1>> BDC', $stream->operators);
+    }
+}

--- a/test/unit/TaggedPdfSerializerTest.php
+++ b/test/unit/TaggedPdfSerializerTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+use Horde\Pdf\ContentStream;
+use Horde\Pdf\DocumentCatalog;
+use Horde\Pdf\Page;
+use Horde\Pdf\PdfSerializer;
+use Horde\Pdf\Rectangle;
+use Horde\Pdf\ResourceDictionary;
+use Horde\Pdf\StructureElement;
+use Horde\Pdf\StructureTree;
+use Horde\Pdf\StructureType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PdfSerializer::class)]
+class TaggedPdfSerializerTest extends TestCase
+{
+    private function buildTaggedCatalog(): DocumentCatalog
+    {
+        $catalog = new DocumentCatalog();
+        $page = new Page(Rectangle::fromDimensions(612, 792));
+        $page->addContentStream(new ContentStream('/P <</MCID 0>> BDC (Hello) Tj EMC', new ResourceDictionary()));
+        $catalog->addPage($page);
+
+        $tree = new StructureTree();
+        $doc = new StructureElement(StructureType::Document);
+        $p = new StructureElement(StructureType::P);
+        $p->addMarkedContent(0, $page);
+        $doc->addChild($p);
+        $tree->add($doc);
+        $catalog->setStructureTree($tree);
+
+        return $catalog;
+    }
+
+    public function testOutputContainsMarkInfo(): void
+    {
+        $output = (new PdfSerializer(compress: false))->serialize($this->buildTaggedCatalog());
+
+        $this->assertStringContainsString('/MarkInfo', $output);
+        $this->assertStringContainsString('/Marked true', $output);
+    }
+
+    public function testOutputContainsStructTreeRoot(): void
+    {
+        $output = (new PdfSerializer(compress: false))->serialize($this->buildTaggedCatalog());
+
+        $this->assertStringContainsString('/StructTreeRoot', $output);
+        $this->assertStringContainsString('/Type /StructTreeRoot', $output);
+    }
+
+    public function testOutputContainsStructElem(): void
+    {
+        $output = (new PdfSerializer(compress: false))->serialize($this->buildTaggedCatalog());
+
+        $this->assertStringContainsString('/Type /StructElem', $output);
+        $this->assertStringContainsString('/S /P', $output);
+        $this->assertStringContainsString('/S /Document', $output);
+    }
+
+    public function testOutputContainsStructParents(): void
+    {
+        $output = (new PdfSerializer(compress: false))->serialize($this->buildTaggedCatalog());
+
+        $this->assertStringContainsString('/StructParents 0', $output);
+    }
+
+    public function testOutputContainsParentTree(): void
+    {
+        $output = (new PdfSerializer(compress: false))->serialize($this->buildTaggedCatalog());
+
+        $this->assertStringContainsString('/Nums [', $output);
+    }
+
+    public function testNestedStructureElements(): void
+    {
+        $catalog = new DocumentCatalog();
+        $page = new Page(Rectangle::fromDimensions(612, 792));
+        $page->addContentStream(new ContentStream('/P <</MCID 0>> BDC (text) Tj EMC', new ResourceDictionary()));
+        $catalog->addPage($page);
+
+        $tree = new StructureTree();
+        $doc = new StructureElement(StructureType::Document);
+        $sect = new StructureElement(StructureType::Sect);
+        $p = new StructureElement(StructureType::P);
+        $p->addMarkedContent(0, $page);
+        $sect->addChild($p);
+        $doc->addChild($sect);
+        $tree->add($doc);
+        $catalog->setStructureTree($tree);
+
+        $output = (new PdfSerializer(compress: false))->serialize($catalog);
+
+        $this->assertStringContainsString('/S /Sect', $output);
+        $this->assertStringContainsString('/S /P', $output);
+        $this->assertStringContainsString('/P ', $output);
+    }
+
+    public function testAltTextSerialized(): void
+    {
+        $catalog = new DocumentCatalog();
+        $page = new Page(Rectangle::fromDimensions(612, 792));
+        $page->addContentStream(new ContentStream('/Figure <</MCID 0>> BDC (img) Tj EMC', new ResourceDictionary()));
+        $catalog->addPage($page);
+
+        $tree = new StructureTree();
+        $doc = new StructureElement(StructureType::Document);
+        $fig = new StructureElement(StructureType::Figure, altText: 'A photo');
+        $fig->addMarkedContent(0, $page);
+        $doc->addChild($fig);
+        $tree->add($doc);
+        $catalog->setStructureTree($tree);
+
+        $output = (new PdfSerializer(compress: false))->serialize($catalog);
+
+        $this->assertStringContainsString('/Alt (A photo)', $output);
+    }
+}

--- a/test/unit/TaggedPdfWriterTest.php
+++ b/test/unit/TaggedPdfWriterTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+use Horde\Pdf\PdfException;
+use Horde\Pdf\PdfWriter;
+use Horde\Pdf\StructureType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PdfWriter::class)]
+class TaggedPdfWriterTest extends TestCase
+{
+    public function testBeginEndStructureProducesTaggedPdf(): void
+    {
+        $pdf = new PdfWriter(compress: false);
+        $pdf->addPage();
+        $pdf->setFont('Helvetica', '', 12);
+
+        $pdf->beginStructure(StructureType::P);
+        $pdf->cell(0, 10, 'Hello tagged world');
+        $pdf->endStructure();
+
+        $output = $pdf->getOutput();
+
+        $this->assertStringContainsString('/MarkInfo', $output);
+        $this->assertStringContainsString('/Marked true', $output);
+        $this->assertStringContainsString('/StructTreeRoot', $output);
+        $this->assertStringContainsString('/Type /StructElem', $output);
+        $this->assertStringContainsString('/S /P', $output);
+        $this->assertStringContainsString('/S /Document', $output);
+        $this->assertStringContainsString('/StructParents 0', $output);
+        $this->assertStringContainsString('/P <</MCID 0>> BDC', $output);
+        $this->assertStringContainsString('EMC', $output);
+    }
+
+    public function testNestedStructures(): void
+    {
+        $pdf = new PdfWriter(compress: false);
+        $pdf->addPage();
+        $pdf->setFont('Helvetica', '', 12);
+
+        $pdf->beginStructure(StructureType::Sect);
+        $pdf->beginStructure(StructureType::H1);
+        $pdf->cell(0, 10, 'Title');
+        $pdf->endStructure();
+        $pdf->beginStructure(StructureType::P);
+        $pdf->cell(0, 10, 'Body text');
+        $pdf->endStructure();
+        $pdf->endStructure();
+
+        $output = $pdf->getOutput();
+
+        $this->assertStringContainsString('/S /Sect', $output);
+        $this->assertStringContainsString('/S /H1', $output);
+        $this->assertStringContainsString('/S /P', $output);
+        $this->assertStringContainsString('/Sect <</MCID 0>> BDC', $output);
+        $this->assertStringContainsString('/H1 <</MCID 1>> BDC', $output);
+        $this->assertStringContainsString('/P <</MCID 2>> BDC', $output);
+    }
+
+    public function testMultiplePagesGetSequentialStructParents(): void
+    {
+        $pdf = new PdfWriter(compress: false);
+
+        $pdf->addPage();
+        $pdf->setFont('Helvetica', '', 12);
+        $pdf->beginStructure(StructureType::P);
+        $pdf->cell(0, 10, 'Page 1');
+        $pdf->endStructure();
+
+        $pdf->addPage();
+        $pdf->beginStructure(StructureType::P);
+        $pdf->cell(0, 10, 'Page 2');
+        $pdf->endStructure();
+
+        $output = $pdf->getOutput();
+
+        $this->assertStringContainsString('/StructParents 0', $output);
+        $this->assertStringContainsString('/StructParents 1', $output);
+    }
+
+    public function testUnclosedStructureThrows(): void
+    {
+        $pdf = new PdfWriter(compress: false);
+        $pdf->addPage();
+        $pdf->setFont('Helvetica', '', 12);
+        $pdf->beginStructure(StructureType::P);
+        $pdf->cell(0, 10, 'text');
+
+        $this->expectException(PdfException::class);
+        $pdf->getOutput();
+    }
+
+    public function testEndStructureWithoutBeginThrows(): void
+    {
+        $pdf = new PdfWriter(compress: false);
+        $pdf->addPage();
+
+        $this->expectException(PdfException::class);
+        $pdf->endStructure();
+    }
+}


### PR DESCRIPTION
## Summary
- Implement Tagged PDF structure tree (ISO 32000-2 §14.8) for accessibility
- StructureType enum, StructureElement, StructureTree classes
- Marked content operators (BDC/BMC/EMC) in ContentStreamBuilder
- Full serialization: MarkInfo, StructTreeRoot, StructElem, ParentTree
- PdfWriter beginStructure/endStructure with auto-managed MCIDs

## Test plan
- [x] StructureType enum values match PDF names
- [x] StructureElement construction, children, marked content
- [x] StructureTree buildParentTree correctness
- [x] Marked content operators emit correct PDF syntax
- [x] Serializer produces /MarkInfo, /StructTreeRoot, /StructElem, /ParentTree
- [x] PdfWriter tagged output validated end-to-end
- [x] Full 505-test suite passes