### PR TITLE
feat: text rendering modes (ISO 32000-2 §9.3.6) #26

### DIFF
--- a/src/ContentStreamBuilder.php
+++ b/src/ContentStreamBuilder.php
@@ -208,6 +208,12 @@ final class ContentStreamBuilder
         return $this;
     }
 
+    public function setTextRenderingMode(TextRenderingMode $mode): self
+    {
+        $this->operators[] = sprintf('%d Tr', $mode->value);
+        return $this;
+    }
+
     // --- Images ---
 
     public function drawImage(

--- a/src/PdfWriter.php
+++ b/src/PdfWriter.php
@@ -46,6 +46,7 @@ final class PdfWriter
 
     private float $lineWidth;
     private float $wordSpacing = 0.0;
+    private TextRenderingMode $textRenderingMode = TextRenderingMode::Fill;
 
     private int $pageNumber = 0;
 
@@ -470,6 +471,15 @@ final class PdfWriter
     public function setFontStyle(string $style): void
     {
         $this->setFont($this->fontFamily, $style);
+    }
+
+    public function setTextRenderingMode(TextRenderingMode $mode): void
+    {
+        $this->textRenderingMode = $mode;
+
+        if ($this->pageNumber > 0) {
+            $this->out(sprintf('BT %d Tr ET', $mode->value));
+        }
     }
 
     public function setTrueTypeFont(Type0Font $font, float $size): void

--- a/src/TextRenderingMode.php
+++ b/src/TextRenderingMode.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+enum TextRenderingMode: int
+{
+    case Fill = 0;
+    case Stroke = 1;
+    case FillStroke = 2;
+    case Invisible = 3;
+    case FillClip = 4;
+    case StrokeClip = 5;
+    case FillStrokeClip = 6;
+    case Clip = 7;
+}

--- a/test/unit/TextRenderingModeTest.php
+++ b/test/unit/TextRenderingModeTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use Horde\Pdf\ContentStreamBuilder;
+use Horde\Pdf\CoreFont;
+use Horde\Pdf\PdfWriter;
+use Horde\Pdf\TextRenderingMode;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(TextRenderingMode::class)]
+#[CoversClass(ContentStreamBuilder::class)]
+#[CoversClass(PdfWriter::class)]
+class TextRenderingModeTest extends TestCase
+{
+    public function testEnumHasEightCases(): void
+    {
+        $cases = TextRenderingMode::cases();
+        $this->assertCount(8, $cases);
+    }
+
+    public function testEnumValues(): void
+    {
+        $this->assertSame(0, TextRenderingMode::Fill->value);
+        $this->assertSame(1, TextRenderingMode::Stroke->value);
+        $this->assertSame(2, TextRenderingMode::FillStroke->value);
+        $this->assertSame(3, TextRenderingMode::Invisible->value);
+        $this->assertSame(4, TextRenderingMode::FillClip->value);
+        $this->assertSame(5, TextRenderingMode::StrokeClip->value);
+        $this->assertSame(6, TextRenderingMode::FillStrokeClip->value);
+        $this->assertSame(7, TextRenderingMode::Clip->value);
+    }
+
+    public function testContentStreamBuilderEmitsTrOperator(): void
+    {
+        $font = CoreFont::Helvetica->toFont();
+        $stream = (new ContentStreamBuilder())
+            ->beginText()
+            ->setFont($font, 12)
+            ->setTextRenderingMode(TextRenderingMode::Stroke)
+            ->showText('test')
+            ->endText()
+            ->build();
+
+        $this->assertStringContainsString('1 Tr', $stream->operators);
+    }
+
+    public function testContentStreamBuilderInvisibleMode(): void
+    {
+        $font = CoreFont::Helvetica->toFont();
+        $stream = (new ContentStreamBuilder())
+            ->beginText()
+            ->setFont($font, 12)
+            ->setTextRenderingMode(TextRenderingMode::Invisible)
+            ->showText('hidden')
+            ->endText()
+            ->build();
+
+        $this->assertStringContainsString('3 Tr', $stream->operators);
+    }
+
+    public function testContentStreamBuilderAllModes(): void
+    {
+        foreach (TextRenderingMode::cases() as $mode) {
+            $stream = (new ContentStreamBuilder())
+                ->setTextRenderingMode($mode)
+                ->build();
+
+            $this->assertSame($mode->value . ' Tr', $stream->operators);
+        }
+    }
+
+    public function testPdfWriterEmitsRenderingMode(): void
+    {
+        $pdf = new PdfWriter(compress: false);
+        $pdf->addPage();
+        $pdf->setFont('Helvetica', '', 12);
+        $pdf->setTextRenderingMode(TextRenderingMode::FillStroke);
+        $pdf->text(10, 10, 'test');
+
+        $output = $pdf->getOutput();
+
+        $this->assertStringContainsString('BT 2 Tr ET', $output);
+    }
+
+    public function testPdfWriterInvisibleMode(): void
+    {
+        $pdf = new PdfWriter(compress: false);
+        $pdf->addPage();
+        $pdf->setFont('Helvetica', '', 12);
+        $pdf->setTextRenderingMode(TextRenderingMode::Invisible);
+        $pdf->text(10, 10, 'OCR overlay');
+
+        $output = $pdf->getOutput();
+
+        $this->assertStringContainsString('BT 3 Tr ET', $output);
+    }
+}


### PR DESCRIPTION
## Summary
- Add TextRenderingMode enum (8 modes: Fill, Stroke, FillStroke, Invisible, FillClip, StrokeClip, FillStrokeClip, Clip)
- Add setTextRenderingMode() to ContentStreamBuilder and PdfWriter
- Key use case: invisible text overlay for searchable scanned documents (OCR)

## Test plan
- [x] Enum has 8 cases with correct int values 0-7
- [x] ContentStreamBuilder emits correct Tr operator for each mode
- [x] PdfWriter emits rendering mode in output
- [x] Full 485-test suite passes