### PR TITLE
feat: ICCBased color space (ISO 32000-2 §8.6.5) #27

### DIFF
--- a/src/ContentStreamBuilder.php
+++ b/src/ContentStreamBuilder.php
@@ -35,6 +35,14 @@ final class ContentStreamBuilder
     /** @var array<int, string> spl_object_id → local name (X1, X2, ...) */
     private array $formNameIndex = [];
 
+    /** @var array<string, IccBasedColorSpace> */
+    private array $colorSpaceMap = [];
+
+    private int $colorSpaceCounter = 0;
+
+    /** @var array<int, string> spl_object_id → local name (CS1, CS2, ...) */
+    private array $colorSpaceNameIndex = [];
+
     // --- Graphics state ---
 
     public function save(): self
@@ -85,6 +93,20 @@ final class ContentStreamBuilder
     public function setStrokeColor(Color $color): self
     {
         $this->operators[] = $color->toPdfStrokeString();
+        return $this;
+    }
+
+    public function setIccFillColor(IccColor $color): self
+    {
+        $localName = $this->registerColorSpace($color->colorSpace());
+        $this->operators[] = $color->toPdfFillString($localName);
+        return $this;
+    }
+
+    public function setIccStrokeColor(IccColor $color): self
+    {
+        $localName = $this->registerColorSpace($color->colorSpace());
+        $this->operators[] = $color->toPdfStrokeString($localName);
         return $this;
     }
 
@@ -318,6 +340,10 @@ final class ContentStreamBuilder
             $resources->addForm($localName, $form);
         }
 
+        foreach ($this->colorSpaceMap as $localName => $cs) {
+            $resources->addColorSpace($localName, $cs);
+        }
+
         $operators = implode("\n", $this->operators);
 
         return new ContentStream($operators, $resources);
@@ -366,6 +392,21 @@ final class ContentStreamBuilder
         $localName = 'X' . (++$this->formCounter);
         $this->formNameIndex[$id] = $localName;
         $this->formMap[$localName] = $form;
+
+        return $localName;
+    }
+
+    private function registerColorSpace(IccBasedColorSpace $cs): string
+    {
+        $id = spl_object_id($cs);
+
+        if (isset($this->colorSpaceNameIndex[$id])) {
+            return $this->colorSpaceNameIndex[$id];
+        }
+
+        $localName = 'CS' . (++$this->colorSpaceCounter);
+        $this->colorSpaceNameIndex[$id] = $localName;
+        $this->colorSpaceMap[$localName] = $cs;
 
         return $localName;
     }

--- a/src/IccBasedColorSpace.php
+++ b/src/IccBasedColorSpace.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+final class IccBasedColorSpace implements ColorSpace
+{
+    public function __construct(
+        public readonly IccProfile $profile,
+    ) {}
+
+    public function pdfName(): string
+    {
+        return 'ICCBased';
+    }
+
+    public function componentCount(): int
+    {
+        return $this->profile->componentCount;
+    }
+}

--- a/src/IccColor.php
+++ b/src/IccColor.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+final class IccColor
+{
+    /** @var array<float> */
+    private array $components;
+
+    public function __construct(
+        private readonly IccBasedColorSpace $colorSpace,
+        float ...$components,
+    ) {
+        if (count($components) !== $colorSpace->componentCount()) {
+            throw new PdfException(sprintf(
+                'Expected %d color components, got %d',
+                $colorSpace->componentCount(),
+                count($components),
+            ));
+        }
+        $this->components = $components;
+    }
+
+    public function colorSpace(): IccBasedColorSpace
+    {
+        return $this->colorSpace;
+    }
+
+    public function toPdfFillString(string $resourceName): string
+    {
+        $values = implode(' ', array_map(
+            fn(float $v) => sprintf('%.3F', $v),
+            $this->components,
+        ));
+        return sprintf('/%s cs %s sc', $resourceName, $values);
+    }
+
+    public function toPdfStrokeString(string $resourceName): string
+    {
+        $values = implode(' ', array_map(
+            fn(float $v) => sprintf('%.3F', $v),
+            $this->components,
+        ));
+        return sprintf('/%s CS %s SC', $resourceName, $values);
+    }
+}

--- a/src/IccProfile.php
+++ b/src/IccProfile.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+final class IccProfile
+{
+    public function __construct(
+        public readonly string $data,
+        public readonly int $componentCount,
+    ) {
+        if ($componentCount < 1 || $componentCount > 4) {
+            throw new PdfException('ICC profile component count must be 1-4');
+        }
+    }
+
+    public function alternateSpace(): string
+    {
+        return match ($this->componentCount) {
+            1 => 'DeviceGray',
+            3 => 'DeviceRGB',
+            4 => 'DeviceCMYK',
+            default => 'DeviceRGB',
+        };
+    }
+}

--- a/src/PdfSerializer.php
+++ b/src/PdfSerializer.php
@@ -41,12 +41,14 @@ final class PdfSerializer
         $allImages = [];
         $allExtGStates = [];
         $allForms = [];
+        $allColorSpaces = [];
         $fontObjNums = [];
         $imageObjNums = [];
         $pageResourceFontObjNums = [];
         $pageResourceImageObjNums = [];
         $pageResourceGStateObjNums = [];
         $pageResourceFormObjNums = [];
+        $pageResourceColorSpaceObjNums = [];
 
         foreach ($pages as $i => $page) {
             $res = $page->resourceDictionary();
@@ -101,11 +103,24 @@ final class PdfSerializer
 
             $pageFormNums = [];
             foreach ($res->forms() as $localName => $form) {
-                $this->collectForm($form, $allForms, $allFonts, $allImages, $allExtGStates, $objectNumber);
+                $this->collectForm($form, $allForms, $allFonts, $allImages, $allExtGStates, $allColorSpaces, $objectNumber);
                 $key = spl_object_id($form);
                 $pageFormNums[$localName] = $allForms[$key]['objNum'];
             }
             $pageResourceFormObjNums[$i] = $pageFormNums;
+
+            $pageCSNums = [];
+            foreach ($res->colorSpaces() as $localName => $cs) {
+                $key = spl_object_id($cs);
+                if (!isset($allColorSpaces[$key])) {
+                    $objectNumber++;
+                    $allColorSpaces[$key] = ['cs' => $cs, 'objNum' => $objectNumber];
+                    $objectNumber++;
+                    $allColorSpaces[$key]['streamObjNum'] = $objectNumber;
+                }
+                $pageCSNums[$localName] = $allColorSpaces[$key]['objNum'];
+            }
+            $pageResourceColorSpaceObjNums[$i] = $pageCSNums;
         }
 
         $resourceDictObjNums = [];
@@ -364,6 +379,40 @@ final class PdfSerializer
             $buffer .= "endobj\n";
         }
 
+        foreach ($allColorSpaces as $entry) {
+            $cs = $entry['cs'];
+            $objNum = $entry['objNum'];
+            $streamObjNum = $entry['streamObjNum'];
+            $profile = $cs->profile;
+
+            $offsets[$objNum] = strlen($buffer);
+            $buffer .= $objNum . " 0 obj\n";
+            $buffer .= "[/ICCBased " . $streamObjNum . " 0 R]\n";
+            $buffer .= "endobj\n";
+
+            $streamData = $this->compress ? @gzcompress($profile->data) : false;
+            $useCompression = $streamData !== false && $this->compress;
+            if (!$useCompression) {
+                $streamData = $profile->data;
+            }
+            if ($encHandler !== null) {
+                $streamData = $encHandler->encryptStream($streamData, $streamObjNum, 0);
+            }
+
+            $offsets[$streamObjNum] = strlen($buffer);
+            $buffer .= $streamObjNum . " 0 obj\n";
+            $buffer .= "<</N " . $profile->componentCount . "\n";
+            $buffer .= "/Alternate /" . $profile->alternateSpace() . "\n";
+            if ($useCompression) {
+                $buffer .= "/Filter /FlateDecode\n";
+            }
+            $buffer .= "/Length " . strlen($streamData) . ">>\n";
+            $buffer .= "stream\n";
+            $buffer .= $streamData . "\n";
+            $buffer .= "endstream\n";
+            $buffer .= "endobj\n";
+        }
+
         foreach ($allForms as $entry) {
             $form = $entry['form'];
             $objNum = $entry['objNum'];
@@ -453,6 +502,14 @@ final class PdfSerializer
                     $buffer .= " >>\n";
                 }
 
+                if (!empty($entry['csObjNums'])) {
+                    $buffer .= "/ColorSpace <<";
+                    foreach ($entry['csObjNums'] as $localName => $csObjNum) {
+                        $buffer .= " /" . $localName . " " . $csObjNum . " 0 R";
+                    }
+                    $buffer .= " >>\n";
+                }
+
                 $buffer .= ">>\n";
                 $buffer .= "endobj\n";
             }
@@ -482,6 +539,13 @@ final class PdfSerializer
             if (!empty($pageResourceGStateObjNums[$i])) {
                 $buffer .= "/ExtGState <<";
                 foreach ($pageResourceGStateObjNums[$i] as $localName => $objNum) {
+                    $buffer .= " /" . $localName . " " . $objNum . " 0 R";
+                }
+                $buffer .= " >>\n";
+            }
+            if (!empty($pageResourceColorSpaceObjNums[$i])) {
+                $buffer .= "/ColorSpace <<";
+                foreach ($pageResourceColorSpaceObjNums[$i] as $localName => $objNum) {
                     $buffer .= " /" . $localName . " " . $objNum . " 0 R";
                 }
                 $buffer .= " >>\n";
@@ -663,6 +727,7 @@ final class PdfSerializer
         array &$allFonts,
         array &$allImages,
         array &$allExtGStates,
+        array &$allColorSpaces,
         int &$objectNumber,
         array $visiting = [],
     ): void {
@@ -731,9 +796,21 @@ final class PdfSerializer
         }
 
         foreach ($res->forms() as $localName => $nestedForm) {
-            $this->collectForm($nestedForm, $allForms, $allFonts, $allImages, $allExtGStates, $objectNumber, $visiting);
+            $this->collectForm($nestedForm, $allForms, $allFonts, $allImages, $allExtGStates, $allColorSpaces, $objectNumber, $visiting);
             $nKey = spl_object_id($nestedForm);
             $formObjNums[$localName] = $allForms[$nKey]['objNum'];
+        }
+
+        $csObjNums = [];
+        foreach ($res->colorSpaces() as $localName => $cs) {
+            $csKey = spl_object_id($cs);
+            if (!isset($allColorSpaces[$csKey])) {
+                $objectNumber++;
+                $allColorSpaces[$csKey] = ['cs' => $cs, 'objNum' => $objectNumber];
+                $objectNumber++;
+                $allColorSpaces[$csKey]['streamObjNum'] = $objectNumber;
+            }
+            $csObjNums[$localName] = $allColorSpaces[$csKey]['objNum'];
         }
 
         if (!$res->isEmpty()) {
@@ -743,6 +820,7 @@ final class PdfSerializer
             $allForms[$key]['imageObjNums'] = $imageObjNums;
             $allForms[$key]['gsObjNums'] = $gsObjNums;
             $allForms[$key]['formObjNums'] = $formObjNums;
+            $allForms[$key]['csObjNums'] = $csObjNums;
         }
     }
 

--- a/src/ResourceDictionary.php
+++ b/src/ResourceDictionary.php
@@ -18,6 +18,9 @@ final class ResourceDictionary
     /** @var array<string, FormXObject> */
     private array $forms = [];
 
+    /** @var array<string, IccBasedColorSpace> */
+    private array $colorSpaces = [];
+
     public function addFont(string $name, Font $font): void
     {
         $this->fonts[$name] = $font;
@@ -36,6 +39,11 @@ final class ResourceDictionary
     public function addForm(string $name, FormXObject $form): void
     {
         $this->forms[$name] = $form;
+    }
+
+    public function addColorSpace(string $name, IccBasedColorSpace $cs): void
+    {
+        $this->colorSpaces[$name] = $cs;
     }
 
     /**
@@ -70,6 +78,14 @@ final class ResourceDictionary
         return $this->forms;
     }
 
+    /**
+     * @return array<string, IccBasedColorSpace>
+     */
+    public function colorSpaces(): array
+    {
+        return $this->colorSpaces;
+    }
+
     public function merge(self $other): void
     {
         foreach ($other->fonts as $name => $font) {
@@ -95,10 +111,20 @@ final class ResourceDictionary
                 $this->forms[$name] = $form;
             }
         }
+
+        foreach ($other->colorSpaces as $name => $cs) {
+            if (!isset($this->colorSpaces[$name])) {
+                $this->colorSpaces[$name] = $cs;
+            }
+        }
     }
 
     public function isEmpty(): bool
     {
-        return empty($this->fonts) && empty($this->images) && empty($this->extGraphicsStates) && empty($this->forms);
+        return empty($this->fonts)
+            && empty($this->images)
+            && empty($this->extGraphicsStates)
+            && empty($this->forms)
+            && empty($this->colorSpaces);
     }
 }

--- a/test/unit/IccColorTest.php
+++ b/test/unit/IccColorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf\Test;
+
+use Horde\Pdf\IccBasedColorSpace;
+use Horde\Pdf\IccColor;
+use Horde\Pdf\IccProfile;
+use Horde\Pdf\PdfException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(IccColor::class)]
+final class IccColorTest extends TestCase
+{
+    private IccBasedColorSpace $rgbSpace;
+
+    protected function setUp(): void
+    {
+        $this->rgbSpace = new IccBasedColorSpace(new IccProfile('data', 3));
+    }
+
+    public function testRejectsWrongComponentCount(): void
+    {
+        $this->expectException(PdfException::class);
+        new IccColor($this->rgbSpace, 0.5, 0.3);
+    }
+
+    public function testColorSpaceAccessor(): void
+    {
+        $color = new IccColor($this->rgbSpace, 0.1, 0.2, 0.3);
+        $this->assertSame($this->rgbSpace, $color->colorSpace());
+    }
+
+    public function testToPdfFillString(): void
+    {
+        $color = new IccColor($this->rgbSpace, 0.5, 0.3, 0.2);
+        $this->assertSame('/CS1 cs 0.500 0.300 0.200 sc', $color->toPdfFillString('CS1'));
+    }
+
+    public function testToPdfStrokeString(): void
+    {
+        $color = new IccColor($this->rgbSpace, 0.5, 0.3, 0.2);
+        $this->assertSame('/CS1 CS 0.500 0.300 0.200 SC', $color->toPdfStrokeString('CS1'));
+    }
+
+    public function testGrayColor(): void
+    {
+        $graySpace = new IccBasedColorSpace(new IccProfile('data', 1));
+        $color = new IccColor($graySpace, 0.75);
+        $this->assertSame('/CS2 cs 0.750 sc', $color->toPdfFillString('CS2'));
+    }
+
+    public function testCmykColor(): void
+    {
+        $cmykSpace = new IccBasedColorSpace(new IccProfile('data', 4));
+        $color = new IccColor($cmykSpace, 1.0, 0.0, 0.5, 0.25);
+        $this->assertSame('/CS3 cs 1.000 0.000 0.500 0.250 sc', $color->toPdfFillString('CS3'));
+    }
+}

--- a/test/unit/IccContentStreamTest.php
+++ b/test/unit/IccContentStreamTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf\Test;
+
+use Horde\Pdf\ContentStreamBuilder;
+use Horde\Pdf\IccBasedColorSpace;
+use Horde\Pdf\IccColor;
+use Horde\Pdf\IccProfile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ContentStreamBuilder::class)]
+final class IccContentStreamTest extends TestCase
+{
+    public function testFillColorEmitsOperators(): void
+    {
+        $cs = new IccBasedColorSpace(new IccProfile('data', 3));
+        $color = new IccColor($cs, 0.5, 0.3, 0.2);
+
+        $stream = (new ContentStreamBuilder())
+            ->setIccFillColor($color)
+            ->build();
+
+        $this->assertStringContainsString('/CS1 cs 0.500 0.300 0.200 sc', $stream->operators);
+    }
+
+    public function testStrokeColorEmitsOperators(): void
+    {
+        $cs = new IccBasedColorSpace(new IccProfile('data', 3));
+        $color = new IccColor($cs, 0.1, 0.9, 0.4);
+
+        $stream = (new ContentStreamBuilder())
+            ->setIccStrokeColor($color)
+            ->build();
+
+        $this->assertStringContainsString('/CS1 CS 0.100 0.900 0.400 SC', $stream->operators);
+    }
+
+    public function testSameColorSpaceReusesResourceName(): void
+    {
+        $cs = new IccBasedColorSpace(new IccProfile('data', 3));
+        $color1 = new IccColor($cs, 0.5, 0.3, 0.2);
+        $color2 = new IccColor($cs, 0.1, 0.2, 0.3);
+
+        $stream = (new ContentStreamBuilder())
+            ->setIccFillColor($color1)
+            ->setIccFillColor($color2)
+            ->build();
+
+        $this->assertStringContainsString('/CS1 cs 0.500 0.300 0.200 sc', $stream->operators);
+        $this->assertStringContainsString('/CS1 cs 0.100 0.200 0.300 sc', $stream->operators);
+
+        $colorSpaces = $stream->resources->colorSpaces();
+        $this->assertCount(1, $colorSpaces);
+        $this->assertArrayHasKey('CS1', $colorSpaces);
+    }
+
+    public function testDifferentColorSpacesGetDifferentNames(): void
+    {
+        $cs1 = new IccBasedColorSpace(new IccProfile('profile1', 3));
+        $cs2 = new IccBasedColorSpace(new IccProfile('profile2', 1));
+
+        $stream = (new ContentStreamBuilder())
+            ->setIccFillColor(new IccColor($cs1, 0.5, 0.3, 0.2))
+            ->setIccFillColor(new IccColor($cs2, 0.8))
+            ->build();
+
+        $colorSpaces = $stream->resources->colorSpaces();
+        $this->assertCount(2, $colorSpaces);
+        $this->assertArrayHasKey('CS1', $colorSpaces);
+        $this->assertArrayHasKey('CS2', $colorSpaces);
+    }
+
+    public function testResourceDictionaryContainsColorSpace(): void
+    {
+        $cs = new IccBasedColorSpace(new IccProfile('data', 3));
+        $color = new IccColor($cs, 0.5, 0.3, 0.2);
+
+        $stream = (new ContentStreamBuilder())
+            ->setIccFillColor($color)
+            ->build();
+
+        $this->assertFalse($stream->resources->isEmpty());
+        $this->assertSame($cs, $stream->resources->colorSpaces()['CS1']);
+    }
+}

--- a/test/unit/IccProfileTest.php
+++ b/test/unit/IccProfileTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf\Test;
+
+use Horde\Pdf\IccProfile;
+use Horde\Pdf\PdfException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(IccProfile::class)]
+final class IccProfileTest extends TestCase
+{
+    public function testConstructorStoresData(): void
+    {
+        $data = str_repeat("\x00", 128);
+        $profile = new IccProfile($data, 3);
+
+        $this->assertSame($data, $profile->data);
+        $this->assertSame(3, $profile->componentCount);
+    }
+
+    public function testRejectsZeroComponents(): void
+    {
+        $this->expectException(PdfException::class);
+        new IccProfile('data', 0);
+    }
+
+    public function testRejectsFiveComponents(): void
+    {
+        $this->expectException(PdfException::class);
+        new IccProfile('data', 5);
+    }
+
+    public function testAlternateSpaceGray(): void
+    {
+        $profile = new IccProfile('data', 1);
+        $this->assertSame('DeviceGray', $profile->alternateSpace());
+    }
+
+    public function testAlternateSpaceRgb(): void
+    {
+        $profile = new IccProfile('data', 3);
+        $this->assertSame('DeviceRGB', $profile->alternateSpace());
+    }
+
+    public function testAlternateSpaceCmyk(): void
+    {
+        $profile = new IccProfile('data', 4);
+        $this->assertSame('DeviceCMYK', $profile->alternateSpace());
+    }
+
+    public function testAlternateSpaceTwoComponents(): void
+    {
+        $profile = new IccProfile('data', 2);
+        $this->assertSame('DeviceRGB', $profile->alternateSpace());
+    }
+}

--- a/test/unit/IccSerializerTest.php
+++ b/test/unit/IccSerializerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf\Test;
+
+use Horde\Pdf\ContentStream;
+use Horde\Pdf\DocumentCatalog;
+use Horde\Pdf\IccBasedColorSpace;
+use Horde\Pdf\IccColor;
+use Horde\Pdf\IccProfile;
+use Horde\Pdf\Page;
+use Horde\Pdf\PdfSerializer;
+use Horde\Pdf\Rectangle;
+use Horde\Pdf\ResourceDictionary;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PdfSerializer::class)]
+#[CoversClass(IccBasedColorSpace::class)]
+#[CoversClass(IccProfile::class)]
+final class IccSerializerTest extends TestCase
+{
+    private function createCatalogWithIcc(IccBasedColorSpace $cs): DocumentCatalog
+    {
+        $catalog = new DocumentCatalog();
+        $resources = new ResourceDictionary();
+        $resources->addColorSpace('CS1', $cs);
+        $content = new ContentStream('/CS1 cs 0.500 0.300 0.200 sc', $resources);
+        $page = new Page(Rectangle::fromDimensions(595.28, 841.89));
+        $page->addContentStream($content);
+        $catalog->addPage($page);
+        return $catalog;
+    }
+
+    public function testColorSpaceInResourceDictionary(): void
+    {
+        $cs = new IccBasedColorSpace(new IccProfile('FAKEPROFILE', 3));
+        $catalog = $this->createCatalogWithIcc($cs);
+
+        $serializer = new PdfSerializer(compress: false);
+        $pdf = $serializer->serialize($catalog);
+
+        $this->assertStringContainsString('/ColorSpace <<', $pdf);
+        $this->assertMatchesRegularExpression('#/CS1 \d+ 0 R#', $pdf);
+    }
+
+    public function testIccArrayObjectReferencesStream(): void
+    {
+        $cs = new IccBasedColorSpace(new IccProfile('FAKEPROFILE', 3));
+        $catalog = $this->createCatalogWithIcc($cs);
+
+        $serializer = new PdfSerializer(compress: false);
+        $pdf = $serializer->serialize($catalog);
+
+        $this->assertMatchesRegularExpression('#\[/ICCBased \d+ 0 R\]#', $pdf);
+    }
+
+    public function testIccStreamHasCorrectAttributes(): void
+    {
+        $profileData = str_repeat('X', 64);
+        $cs = new IccBasedColorSpace(new IccProfile($profileData, 3));
+        $catalog = $this->createCatalogWithIcc($cs);
+
+        $serializer = new PdfSerializer(compress: false);
+        $pdf = $serializer->serialize($catalog);
+
+        $this->assertStringContainsString('/N 3', $pdf);
+        $this->assertStringContainsString('/Alternate /DeviceRGB', $pdf);
+        $this->assertStringContainsString('/Length 64', $pdf);
+    }
+
+    public function testIccStreamContainsProfileData(): void
+    {
+        $profileData = 'TESTPROFILEDATA1234';
+        $cs = new IccBasedColorSpace(new IccProfile($profileData, 3));
+        $catalog = $this->createCatalogWithIcc($cs);
+
+        $serializer = new PdfSerializer(compress: false);
+        $pdf = $serializer->serialize($catalog);
+
+        $this->assertStringContainsString($profileData, $pdf);
+    }
+
+    public function testGrayProfileAlternate(): void
+    {
+        $cs = new IccBasedColorSpace(new IccProfile('GRAYDATA', 1));
+        $catalog = $this->createCatalogWithIcc($cs);
+
+        $serializer = new PdfSerializer(compress: false);
+        $pdf = $serializer->serialize($catalog);
+
+        $this->assertStringContainsString('/N 1', $pdf);
+        $this->assertStringContainsString('/Alternate /DeviceGray', $pdf);
+    }
+
+    public function testCmykProfileAlternate(): void
+    {
+        $cs = new IccBasedColorSpace(new IccProfile('CMYKDATA', 4));
+        $catalog = $this->createCatalogWithIcc($cs);
+
+        $serializer = new PdfSerializer(compress: false);
+        $pdf = $serializer->serialize($catalog);
+
+        $this->assertStringContainsString('/N 4', $pdf);
+        $this->assertStringContainsString('/Alternate /DeviceCMYK', $pdf);
+    }
+
+    public function testCompressedIccStream(): void
+    {
+        $profileData = str_repeat('ABCDEFGH', 100);
+        $cs = new IccBasedColorSpace(new IccProfile($profileData, 3));
+        $catalog = $this->createCatalogWithIcc($cs);
+
+        $serializer = new PdfSerializer(compress: true);
+        $pdf = $serializer->serialize($catalog);
+
+        $this->assertStringContainsString('/Filter /FlateDecode', $pdf);
+        $this->assertStringNotContainsString($profileData, $pdf);
+    }
+}


### PR DESCRIPTION
## Summary

- Add ICCBased color space support with ICC profile stream objects
- New classes: IccProfile, IccBasedColorSpace, IccColor
- Extend ResourceDictionary with /ColorSpace category
- ContentStreamBuilder gains setIccFillColor/setIccStrokeColor methods
- PdfSerializer emits ICC array + profile stream objects

## Test plan

- [x] IccProfile validates component count, derives alternate space
- [x] IccColor emits correct cs/CS + sc/SC operators
- [x] ContentStreamBuilder registers and reuses ICC color space resources
- [x] PdfSerializer produces valid /ColorSpace dict, ICC array and stream objects
- [x] Full regression suite passes (562 tests)