### PR TITLE
feat: Separation and DeviceN color spaces (ISO 32000-2 §8.6.6-7) #28

### DIFF
--- a/src/ContentStreamBuilder.php
+++ b/src/ContentStreamBuilder.php
@@ -35,7 +35,7 @@ final class ContentStreamBuilder
     /** @var array<int, string> spl_object_id → local name (X1, X2, ...) */
     private array $formNameIndex = [];
 
-    /** @var array<string, IccBasedColorSpace> */
+    /** @var array<string, ColorSpace> */
     private array $colorSpaceMap = [];
 
     private int $colorSpaceCounter = 0;
@@ -104,6 +104,34 @@ final class ContentStreamBuilder
     }
 
     public function setIccStrokeColor(IccColor $color): self
+    {
+        $localName = $this->registerColorSpace($color->colorSpace());
+        $this->operators[] = $color->toPdfStrokeString($localName);
+        return $this;
+    }
+
+    public function setSeparationFillColor(SeparationColor $color): self
+    {
+        $localName = $this->registerColorSpace($color->colorSpace());
+        $this->operators[] = $color->toPdfFillString($localName);
+        return $this;
+    }
+
+    public function setSeparationStrokeColor(SeparationColor $color): self
+    {
+        $localName = $this->registerColorSpace($color->colorSpace());
+        $this->operators[] = $color->toPdfStrokeString($localName);
+        return $this;
+    }
+
+    public function setDeviceNFillColor(DeviceNColor $color): self
+    {
+        $localName = $this->registerColorSpace($color->colorSpace());
+        $this->operators[] = $color->toPdfFillString($localName);
+        return $this;
+    }
+
+    public function setDeviceNStrokeColor(DeviceNColor $color): self
     {
         $localName = $this->registerColorSpace($color->colorSpace());
         $this->operators[] = $color->toPdfStrokeString($localName);
@@ -396,7 +424,7 @@ final class ContentStreamBuilder
         return $localName;
     }
 
-    private function registerColorSpace(IccBasedColorSpace $cs): string
+    private function registerColorSpace(ColorSpace $cs): string
     {
         $id = spl_object_id($cs);
 

--- a/src/DeviceNColor.php
+++ b/src/DeviceNColor.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+final class DeviceNColor
+{
+    /** @var array<float> */
+    private array $tints;
+
+    public function __construct(
+        private readonly DeviceNColorSpace $colorSpace,
+        float ...$tints,
+    ) {
+        if (count($tints) !== $colorSpace->componentCount()) {
+            throw new PdfException(sprintf(
+                'Expected %d tint values, got %d',
+                $colorSpace->componentCount(),
+                count($tints),
+            ));
+        }
+        $this->tints = $tints;
+    }
+
+    public function colorSpace(): DeviceNColorSpace
+    {
+        return $this->colorSpace;
+    }
+
+    public function toPdfFillString(string $resourceName): string
+    {
+        $values = implode(' ', array_map(
+            fn(float $v) => sprintf('%.3F', $v),
+            $this->tints,
+        ));
+        return sprintf('/%s cs %s sc', $resourceName, $values);
+    }
+
+    public function toPdfStrokeString(string $resourceName): string
+    {
+        $values = implode(' ', array_map(
+            fn(float $v) => sprintf('%.3F', $v),
+            $this->tints,
+        ));
+        return sprintf('/%s CS %s SC', $resourceName, $values);
+    }
+}

--- a/src/DeviceNColorSpace.php
+++ b/src/DeviceNColorSpace.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+final class DeviceNColorSpace implements ColorSpace
+{
+    /** @param array<string> $colorantNames */
+    public function __construct(
+        public readonly array $colorantNames,
+        public readonly ColorSpace $alternateSpace,
+        public readonly PdfFunction $tintTransform,
+    ) {}
+
+    public function pdfName(): string
+    {
+        return 'DeviceN';
+    }
+
+    public function componentCount(): int
+    {
+        return count($this->colorantNames);
+    }
+}

--- a/src/ExponentialFunction.php
+++ b/src/ExponentialFunction.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+final class ExponentialFunction implements PdfFunction
+{
+    /**
+     * @param array<float> $c0 Function result when input is 0
+     * @param array<float> $c1 Function result when input is 1
+     */
+    public function __construct(
+        public readonly array $c0,
+        public readonly array $c1,
+        public readonly float $exponent = 1.0,
+    ) {}
+
+    public function functionType(): int
+    {
+        return 2;
+    }
+
+    public function domain(): array
+    {
+        return [0.0, 1.0];
+    }
+
+    public function range(): array
+    {
+        $range = [];
+        $count = count($this->c0);
+        for ($i = 0; $i < $count; $i++) {
+            $range[] = min($this->c0[$i], $this->c1[$i]);
+            $range[] = max($this->c0[$i], $this->c1[$i]);
+        }
+        return $range;
+    }
+}

--- a/src/PdfFunction.php
+++ b/src/PdfFunction.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+interface PdfFunction
+{
+    public function functionType(): int;
+
+    /** @return array<float> */
+    public function domain(): array;
+
+    /** @return array<float> */
+    public function range(): array;
+}

--- a/src/PdfSerializer.php
+++ b/src/PdfSerializer.php
@@ -116,7 +116,14 @@ final class PdfSerializer
                     $objectNumber++;
                     $allColorSpaces[$key] = ['cs' => $cs, 'objNum' => $objectNumber];
                     $objectNumber++;
-                    $allColorSpaces[$key]['streamObjNum'] = $objectNumber;
+                    $allColorSpaces[$key]['auxObjNum'] = $objectNumber;
+                    if ($cs instanceof IccBasedColorSpace) {
+                        $allColorSpaces[$key]['type'] = 'icc';
+                    } elseif ($cs instanceof SeparationColorSpace) {
+                        $allColorSpaces[$key]['type'] = 'separation';
+                    } elseif ($cs instanceof DeviceNColorSpace) {
+                        $allColorSpaces[$key]['type'] = 'devicen';
+                    }
                 }
                 $pageCSNums[$localName] = $allColorSpaces[$key]['objNum'];
             }
@@ -382,34 +389,51 @@ final class PdfSerializer
         foreach ($allColorSpaces as $entry) {
             $cs = $entry['cs'];
             $objNum = $entry['objNum'];
-            $streamObjNum = $entry['streamObjNum'];
-            $profile = $cs->profile;
+            $auxObjNum = $entry['auxObjNum'];
+            $type = $entry['type'];
 
             $offsets[$objNum] = strlen($buffer);
             $buffer .= $objNum . " 0 obj\n";
-            $buffer .= "[/ICCBased " . $streamObjNum . " 0 R]\n";
+
+            if ($type === 'icc') {
+                $buffer .= "[/ICCBased " . $auxObjNum . " 0 R]\n";
+            } elseif ($type === 'separation') {
+                $altName = $cs->alternateSpace->pdfName();
+                $buffer .= "[/Separation /" . $cs->colorantName . " /" . $altName . " " . $auxObjNum . " 0 R]\n";
+            } elseif ($type === 'devicen') {
+                $names = implode(' ', array_map(fn(string $n) => '/' . $n, $cs->colorantNames));
+                $altName = $cs->alternateSpace->pdfName();
+                $buffer .= "[/DeviceN [" . $names . "] /" . $altName . " " . $auxObjNum . " 0 R]\n";
+            }
+
             $buffer .= "endobj\n";
 
-            $streamData = $this->compress ? @gzcompress($profile->data) : false;
-            $useCompression = $streamData !== false && $this->compress;
-            if (!$useCompression) {
-                $streamData = $profile->data;
-            }
-            if ($encHandler !== null) {
-                $streamData = $encHandler->encryptStream($streamData, $streamObjNum, 0);
+            $offsets[$auxObjNum] = strlen($buffer);
+            $buffer .= $auxObjNum . " 0 obj\n";
+
+            if ($type === 'icc') {
+                $profile = $cs->profile;
+                $streamData = $this->compress ? @gzcompress($profile->data) : false;
+                $useCompression = $streamData !== false && $this->compress;
+                if (!$useCompression) {
+                    $streamData = $profile->data;
+                }
+                if ($encHandler !== null) {
+                    $streamData = $encHandler->encryptStream($streamData, $auxObjNum, 0);
+                }
+                $buffer .= "<</N " . $profile->componentCount . "\n";
+                $buffer .= "/Alternate /" . $profile->alternateSpace() . "\n";
+                if ($useCompression) {
+                    $buffer .= "/Filter /FlateDecode\n";
+                }
+                $buffer .= "/Length " . strlen($streamData) . ">>\n";
+                $buffer .= "stream\n";
+                $buffer .= $streamData . "\n";
+                $buffer .= "endstream\n";
+            } else {
+                $this->serializePdfFunction($buffer, $cs->tintTransform, $auxObjNum, $encHandler);
             }
 
-            $offsets[$streamObjNum] = strlen($buffer);
-            $buffer .= $streamObjNum . " 0 obj\n";
-            $buffer .= "<</N " . $profile->componentCount . "\n";
-            $buffer .= "/Alternate /" . $profile->alternateSpace() . "\n";
-            if ($useCompression) {
-                $buffer .= "/Filter /FlateDecode\n";
-            }
-            $buffer .= "/Length " . strlen($streamData) . ">>\n";
-            $buffer .= "stream\n";
-            $buffer .= $streamData . "\n";
-            $buffer .= "endstream\n";
             $buffer .= "endobj\n";
         }
 
@@ -721,6 +745,30 @@ final class PdfSerializer
      * @param array<string, mixed> $allExtGStates
      * @param array<int, bool> $visiting
      */
+    private function serializePdfFunction(string &$buffer, PdfFunction $fn, int $objNum, ?EncryptionHandler $encHandler): void
+    {
+        if ($fn instanceof ExponentialFunction) {
+            $buffer .= "<</FunctionType 2\n";
+            $buffer .= "/Domain [" . implode(' ', array_map(fn(float $v) => sprintf('%.1F', $v), $fn->domain())) . "]\n";
+            $buffer .= "/C0 [" . implode(' ', array_map(fn(float $v) => sprintf('%.4F', $v), $fn->c0)) . "]\n";
+            $buffer .= "/C1 [" . implode(' ', array_map(fn(float $v) => sprintf('%.4F', $v), $fn->c1)) . "]\n";
+            $buffer .= sprintf("/N %.1F>>\n", $fn->exponent);
+        } elseif ($fn instanceof PostScriptFunction) {
+            $code = '{ ' . $fn->code . ' }';
+            $streamData = $code;
+            if ($encHandler !== null) {
+                $streamData = $encHandler->encryptStream($streamData, $objNum, 0);
+            }
+            $buffer .= "<</FunctionType 4\n";
+            $buffer .= "/Domain [" . implode(' ', array_map(fn(float $v) => sprintf('%.1F', $v), $fn->domain())) . "]\n";
+            $buffer .= "/Range [" . implode(' ', array_map(fn(float $v) => sprintf('%.1F', $v), $fn->range())) . "]\n";
+            $buffer .= "/Length " . strlen($streamData) . ">>\n";
+            $buffer .= "stream\n";
+            $buffer .= $streamData . "\n";
+            $buffer .= "endstream\n";
+        }
+    }
+
     private function collectForm(
         FormXObject $form,
         array &$allForms,
@@ -808,7 +856,14 @@ final class PdfSerializer
                 $objectNumber++;
                 $allColorSpaces[$csKey] = ['cs' => $cs, 'objNum' => $objectNumber];
                 $objectNumber++;
-                $allColorSpaces[$csKey]['streamObjNum'] = $objectNumber;
+                $allColorSpaces[$csKey]['auxObjNum'] = $objectNumber;
+                if ($cs instanceof IccBasedColorSpace) {
+                    $allColorSpaces[$csKey]['type'] = 'icc';
+                } elseif ($cs instanceof SeparationColorSpace) {
+                    $allColorSpaces[$csKey]['type'] = 'separation';
+                } elseif ($cs instanceof DeviceNColorSpace) {
+                    $allColorSpaces[$csKey]['type'] = 'devicen';
+                }
             }
             $csObjNums[$localName] = $allColorSpaces[$csKey]['objNum'];
         }

--- a/src/PostScriptFunction.php
+++ b/src/PostScriptFunction.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+final class PostScriptFunction implements PdfFunction
+{
+    /**
+     * @param array<float> $domain Input domain pairs [min0, max0, min1, max1, ...]
+     * @param array<float> $range Output range pairs [min0, max0, min1, max1, ...]
+     */
+    public function __construct(
+        public readonly string $code,
+        public readonly array $domain,
+        public readonly array $range,
+    ) {}
+
+    public function functionType(): int
+    {
+        return 4;
+    }
+
+    public function domain(): array
+    {
+        return $this->domain;
+    }
+
+    public function range(): array
+    {
+        return $this->range;
+    }
+}

--- a/src/ResourceDictionary.php
+++ b/src/ResourceDictionary.php
@@ -18,7 +18,7 @@ final class ResourceDictionary
     /** @var array<string, FormXObject> */
     private array $forms = [];
 
-    /** @var array<string, IccBasedColorSpace> */
+    /** @var array<string, ColorSpace> */
     private array $colorSpaces = [];
 
     public function addFont(string $name, Font $font): void
@@ -41,7 +41,7 @@ final class ResourceDictionary
         $this->forms[$name] = $form;
     }
 
-    public function addColorSpace(string $name, IccBasedColorSpace $cs): void
+    public function addColorSpace(string $name, ColorSpace $cs): void
     {
         $this->colorSpaces[$name] = $cs;
     }
@@ -79,7 +79,7 @@ final class ResourceDictionary
     }
 
     /**
-     * @return array<string, IccBasedColorSpace>
+     * @return array<string, ColorSpace>
      */
     public function colorSpaces(): array
     {

--- a/src/SeparationColor.php
+++ b/src/SeparationColor.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+final class SeparationColor
+{
+    public function __construct(
+        private readonly SeparationColorSpace $colorSpace,
+        private readonly float $tint,
+    ) {}
+
+    public function colorSpace(): SeparationColorSpace
+    {
+        return $this->colorSpace;
+    }
+
+    public function toPdfFillString(string $resourceName): string
+    {
+        return sprintf('/%s cs %.3F sc', $resourceName, $this->tint);
+    }
+
+    public function toPdfStrokeString(string $resourceName): string
+    {
+        return sprintf('/%s CS %.3F SC', $resourceName, $this->tint);
+    }
+}

--- a/src/SeparationColorSpace.php
+++ b/src/SeparationColorSpace.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf;
+
+final class SeparationColorSpace implements ColorSpace
+{
+    public function __construct(
+        public readonly string $colorantName,
+        public readonly ColorSpace $alternateSpace,
+        public readonly PdfFunction $tintTransform,
+    ) {}
+
+    public function pdfName(): string
+    {
+        return 'Separation';
+    }
+
+    public function componentCount(): int
+    {
+        return 1;
+    }
+}

--- a/test/unit/DeviceNColorSpaceTest.php
+++ b/test/unit/DeviceNColorSpaceTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf\Test;
+
+use Horde\Pdf\DeviceCmyk;
+use Horde\Pdf\DeviceNColorSpace;
+use Horde\Pdf\ExponentialFunction;
+use Horde\Pdf\PostScriptFunction;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DeviceNColorSpace::class)]
+final class DeviceNColorSpaceTest extends TestCase
+{
+    public function testPdfName(): void
+    {
+        $cs = new DeviceNColorSpace(
+            ['Cyan', 'Magenta'],
+            new DeviceCmyk(),
+            new PostScriptFunction('pop pop 0 0 0 0', [0.0, 1.0, 0.0, 1.0], [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]),
+        );
+        $this->assertSame('DeviceN', $cs->pdfName());
+    }
+
+    public function testComponentCountMatchesColorants(): void
+    {
+        $cs = new DeviceNColorSpace(
+            ['Spot1', 'Spot2', 'Spot3'],
+            new DeviceCmyk(),
+            new PostScriptFunction('pop pop pop 0 0 0 0', [0.0, 1.0, 0.0, 1.0, 0.0, 1.0], [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]),
+        );
+        $this->assertSame(3, $cs->componentCount());
+    }
+
+    public function testStoresColorantNames(): void
+    {
+        $names = ['PANTONE 300 C', 'PANTONE 485 C'];
+        $cs = new DeviceNColorSpace(
+            $names,
+            new DeviceCmyk(),
+            new ExponentialFunction([0.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]),
+        );
+        $this->assertSame($names, $cs->colorantNames);
+    }
+}

--- a/test/unit/DeviceNColorTest.php
+++ b/test/unit/DeviceNColorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf\Test;
+
+use Horde\Pdf\DeviceCmyk;
+use Horde\Pdf\DeviceNColor;
+use Horde\Pdf\DeviceNColorSpace;
+use Horde\Pdf\PdfException;
+use Horde\Pdf\PostScriptFunction;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DeviceNColor::class)]
+final class DeviceNColorTest extends TestCase
+{
+    private DeviceNColorSpace $cs;
+
+    protected function setUp(): void
+    {
+        $this->cs = new DeviceNColorSpace(
+            ['Spot1', 'Spot2'],
+            new DeviceCmyk(),
+            new PostScriptFunction('pop pop 0 0 0 0', [0.0, 1.0, 0.0, 1.0], [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]),
+        );
+    }
+
+    public function testRejectsWrongTintCount(): void
+    {
+        $this->expectException(PdfException::class);
+        new DeviceNColor($this->cs, 0.5);
+    }
+
+    public function testToPdfFillString(): void
+    {
+        $color = new DeviceNColor($this->cs, 0.5, 0.8);
+        $this->assertSame('/CS1 cs 0.500 0.800 sc', $color->toPdfFillString('CS1'));
+    }
+
+    public function testToPdfStrokeString(): void
+    {
+        $color = new DeviceNColor($this->cs, 1.0, 0.0);
+        $this->assertSame('/CS1 CS 1.000 0.000 SC', $color->toPdfStrokeString('CS1'));
+    }
+
+    public function testColorSpaceAccessor(): void
+    {
+        $color = new DeviceNColor($this->cs, 0.3, 0.7);
+        $this->assertSame($this->cs, $color->colorSpace());
+    }
+}

--- a/test/unit/DeviceNSerializerTest.php
+++ b/test/unit/DeviceNSerializerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf\Test;
+
+use Horde\Pdf\ContentStream;
+use Horde\Pdf\DeviceCmyk;
+use Horde\Pdf\DeviceNColorSpace;
+use Horde\Pdf\DocumentCatalog;
+use Horde\Pdf\ExponentialFunction;
+use Horde\Pdf\Page;
+use Horde\Pdf\PdfSerializer;
+use Horde\Pdf\PostScriptFunction;
+use Horde\Pdf\Rectangle;
+use Horde\Pdf\ResourceDictionary;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PdfSerializer::class)]
+#[CoversClass(DeviceNColorSpace::class)]
+#[CoversClass(PostScriptFunction::class)]
+final class DeviceNSerializerTest extends TestCase
+{
+    private function createCatalog(DeviceNColorSpace $cs): DocumentCatalog
+    {
+        $catalog = new DocumentCatalog();
+        $resources = new ResourceDictionary();
+        $resources->addColorSpace('CS1', $cs);
+        $content = new ContentStream('/CS1 cs 0.500 0.800 sc', $resources);
+        $page = new Page(Rectangle::fromDimensions(595.28, 841.89));
+        $page->addContentStream($content);
+        $catalog->addPage($page);
+        return $catalog;
+    }
+
+    public function testDeviceNArrayObject(): void
+    {
+        $cs = new DeviceNColorSpace(
+            ['Spot1', 'Spot2'],
+            new DeviceCmyk(),
+            new ExponentialFunction([0.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.5, 0.0]),
+        );
+        $pdf = (new PdfSerializer(compress: false))->serialize($this->createCatalog($cs));
+
+        $this->assertMatchesRegularExpression('#\[/DeviceN \[/Spot1 /Spot2\] /DeviceCMYK \d+ 0 R\]#', $pdf);
+    }
+
+    public function testColorSpaceInResourceDict(): void
+    {
+        $cs = new DeviceNColorSpace(
+            ['Spot1', 'Spot2'],
+            new DeviceCmyk(),
+            new ExponentialFunction([0.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.5, 0.0]),
+        );
+        $pdf = (new PdfSerializer(compress: false))->serialize($this->createCatalog($cs));
+
+        $this->assertStringContainsString('/ColorSpace <<', $pdf);
+    }
+
+    public function testPostScriptFunction(): void
+    {
+        $cs = new DeviceNColorSpace(
+            ['Cyan', 'Magenta'],
+            new DeviceCmyk(),
+            new PostScriptFunction(
+                'exch 0 0',
+                [0.0, 1.0, 0.0, 1.0],
+                [0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+            ),
+        );
+        $pdf = (new PdfSerializer(compress: false))->serialize($this->createCatalog($cs));
+
+        $this->assertStringContainsString('/FunctionType 4', $pdf);
+        $this->assertStringContainsString('/Domain [0.0 1.0 0.0 1.0]', $pdf);
+        $this->assertStringContainsString('/Range [0.0 1.0 0.0 1.0 0.0 1.0 0.0 1.0]', $pdf);
+        $this->assertStringContainsString('{ exch 0 0 }', $pdf);
+    }
+
+    public function testThreeColorants(): void
+    {
+        $cs = new DeviceNColorSpace(
+            ['Red', 'Green', 'Blue'],
+            new DeviceCmyk(),
+            new ExponentialFunction([0.0, 0.0, 0.0, 0.0], [1.0, 1.0, 1.0, 0.0]),
+        );
+        $pdf = (new PdfSerializer(compress: false))->serialize($this->createCatalog($cs));
+
+        $this->assertMatchesRegularExpression('#\[/DeviceN \[/Red /Green /Blue\] /DeviceCMYK \d+ 0 R\]#', $pdf);
+    }
+}

--- a/test/unit/ExponentialFunctionTest.php
+++ b/test/unit/ExponentialFunctionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf\Test;
+
+use Horde\Pdf\ExponentialFunction;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ExponentialFunction::class)]
+final class ExponentialFunctionTest extends TestCase
+{
+    public function testFunctionType(): void
+    {
+        $fn = new ExponentialFunction([1.0, 1.0, 1.0, 1.0], [0.0, 0.5, 0.8, 0.2]);
+        $this->assertSame(2, $fn->functionType());
+    }
+
+    public function testDomain(): void
+    {
+        $fn = new ExponentialFunction([1.0, 1.0, 1.0], [0.0, 0.0, 0.0]);
+        $this->assertSame([0.0, 1.0], $fn->domain());
+    }
+
+    public function testRange(): void
+    {
+        $fn = new ExponentialFunction([1.0, 0.5], [0.0, 1.0]);
+        $range = $fn->range();
+        $this->assertSame([0.0, 1.0, 0.5, 1.0], $range);
+    }
+
+    public function testStoresValues(): void
+    {
+        $fn = new ExponentialFunction([1.0, 1.0, 1.0], [0.0, 0.5, 0.8], 2.2);
+        $this->assertSame([1.0, 1.0, 1.0], $fn->c0);
+        $this->assertSame([0.0, 0.5, 0.8], $fn->c1);
+        $this->assertSame(2.2, $fn->exponent);
+    }
+
+    public function testDefaultExponent(): void
+    {
+        $fn = new ExponentialFunction([1.0], [0.0]);
+        $this->assertSame(1.0, $fn->exponent);
+    }
+}

--- a/test/unit/PostScriptFunctionTest.php
+++ b/test/unit/PostScriptFunctionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf\Test;
+
+use Horde\Pdf\PostScriptFunction;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PostScriptFunction::class)]
+final class PostScriptFunctionTest extends TestCase
+{
+    public function testFunctionType(): void
+    {
+        $fn = new PostScriptFunction('1 exch sub', [0.0, 1.0], [0.0, 1.0]);
+        $this->assertSame(4, $fn->functionType());
+    }
+
+    public function testStoresCode(): void
+    {
+        $code = '1 exch sub 0.5 mul';
+        $fn = new PostScriptFunction($code, [0.0, 1.0], [0.0, 1.0]);
+        $this->assertSame($code, $fn->code);
+    }
+
+    public function testDomain(): void
+    {
+        $fn = new PostScriptFunction('pop 0', [0.0, 1.0], [0.0, 1.0, 0.0, 1.0, 0.0, 1.0]);
+        $this->assertSame([0.0, 1.0], $fn->domain());
+    }
+
+    public function testRange(): void
+    {
+        $range = [0.0, 1.0, 0.0, 1.0, 0.0, 1.0];
+        $fn = new PostScriptFunction('pop 0', [0.0, 1.0], $range);
+        $this->assertSame($range, $fn->range());
+    }
+}

--- a/test/unit/SeparationColorSpaceTest.php
+++ b/test/unit/SeparationColorSpaceTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf\Test;
+
+use Horde\Pdf\DeviceCmyk;
+use Horde\Pdf\ExponentialFunction;
+use Horde\Pdf\SeparationColorSpace;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SeparationColorSpace::class)]
+final class SeparationColorSpaceTest extends TestCase
+{
+    public function testPdfName(): void
+    {
+        $cs = new SeparationColorSpace(
+            'PANTONE 300 C',
+            new DeviceCmyk(),
+            new ExponentialFunction([0.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]),
+        );
+        $this->assertSame('Separation', $cs->pdfName());
+    }
+
+    public function testComponentCount(): void
+    {
+        $cs = new SeparationColorSpace(
+            'SpotGreen',
+            new DeviceCmyk(),
+            new ExponentialFunction([0.0, 0.0, 0.0, 0.0], [0.5, 0.0, 1.0, 0.0]),
+        );
+        $this->assertSame(1, $cs->componentCount());
+    }
+
+    public function testStoresColorantName(): void
+    {
+        $cs = new SeparationColorSpace(
+            'PANTONE 300 C',
+            new DeviceCmyk(),
+            new ExponentialFunction([0.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]),
+        );
+        $this->assertSame('PANTONE 300 C', $cs->colorantName);
+    }
+
+    public function testStoresAlternateSpace(): void
+    {
+        $alt = new DeviceCmyk();
+        $cs = new SeparationColorSpace(
+            'Spot',
+            $alt,
+            new ExponentialFunction([0.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]),
+        );
+        $this->assertSame($alt, $cs->alternateSpace);
+    }
+}

--- a/test/unit/SeparationColorTest.php
+++ b/test/unit/SeparationColorTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf\Test;
+
+use Horde\Pdf\DeviceCmyk;
+use Horde\Pdf\ExponentialFunction;
+use Horde\Pdf\SeparationColor;
+use Horde\Pdf\SeparationColorSpace;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SeparationColor::class)]
+final class SeparationColorTest extends TestCase
+{
+    private SeparationColorSpace $cs;
+
+    protected function setUp(): void
+    {
+        $this->cs = new SeparationColorSpace(
+            'SpotBlue',
+            new DeviceCmyk(),
+            new ExponentialFunction([0.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]),
+        );
+    }
+
+    public function testToPdfFillString(): void
+    {
+        $color = new SeparationColor($this->cs, 0.75);
+        $this->assertSame('/CS1 cs 0.750 sc', $color->toPdfFillString('CS1'));
+    }
+
+    public function testToPdfStrokeString(): void
+    {
+        $color = new SeparationColor($this->cs, 0.25);
+        $this->assertSame('/CS2 CS 0.250 SC', $color->toPdfStrokeString('CS2'));
+    }
+
+    public function testFullTint(): void
+    {
+        $color = new SeparationColor($this->cs, 1.0);
+        $this->assertSame('/CS1 cs 1.000 sc', $color->toPdfFillString('CS1'));
+    }
+
+    public function testColorSpaceAccessor(): void
+    {
+        $color = new SeparationColor($this->cs, 0.5);
+        $this->assertSame($this->cs, $color->colorSpace());
+    }
+}

--- a/test/unit/SeparationSerializerTest.php
+++ b/test/unit/SeparationSerializerTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Horde\Pdf\Test;
+
+use Horde\Pdf\ContentStream;
+use Horde\Pdf\DeviceCmyk;
+use Horde\Pdf\DeviceRgb;
+use Horde\Pdf\DocumentCatalog;
+use Horde\Pdf\ExponentialFunction;
+use Horde\Pdf\Page;
+use Horde\Pdf\PdfSerializer;
+use Horde\Pdf\Rectangle;
+use Horde\Pdf\ResourceDictionary;
+use Horde\Pdf\SeparationColorSpace;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PdfSerializer::class)]
+#[CoversClass(SeparationColorSpace::class)]
+#[CoversClass(ExponentialFunction::class)]
+final class SeparationSerializerTest extends TestCase
+{
+    private function createCatalog(SeparationColorSpace $cs): DocumentCatalog
+    {
+        $catalog = new DocumentCatalog();
+        $resources = new ResourceDictionary();
+        $resources->addColorSpace('CS1', $cs);
+        $content = new ContentStream('/CS1 cs 0.750 sc', $resources);
+        $page = new Page(Rectangle::fromDimensions(595.28, 841.89));
+        $page->addContentStream($content);
+        $catalog->addPage($page);
+        return $catalog;
+    }
+
+    public function testColorSpaceInResourceDict(): void
+    {
+        $cs = new SeparationColorSpace(
+            'SpotBlue',
+            new DeviceCmyk(),
+            new ExponentialFunction([0.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]),
+        );
+        $pdf = (new PdfSerializer(compress: false))->serialize($this->createCatalog($cs));
+
+        $this->assertStringContainsString('/ColorSpace <<', $pdf);
+        $this->assertMatchesRegularExpression('#/CS1 \d+ 0 R#', $pdf);
+    }
+
+    public function testSeparationArrayObject(): void
+    {
+        $cs = new SeparationColorSpace(
+            'SpotBlue',
+            new DeviceCmyk(),
+            new ExponentialFunction([0.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]),
+        );
+        $pdf = (new PdfSerializer(compress: false))->serialize($this->createCatalog($cs));
+
+        $this->assertMatchesRegularExpression('#\[/Separation /SpotBlue /DeviceCMYK \d+ 0 R\]#', $pdf);
+    }
+
+    public function testExponentialFunctionObject(): void
+    {
+        $cs = new SeparationColorSpace(
+            'SpotGreen',
+            new DeviceCmyk(),
+            new ExponentialFunction([0.0, 0.0, 0.0, 0.0], [0.5, 0.0, 1.0, 0.2]),
+        );
+        $pdf = (new PdfSerializer(compress: false))->serialize($this->createCatalog($cs));
+
+        $this->assertStringContainsString('/FunctionType 2', $pdf);
+        $this->assertStringContainsString('/Domain [0.0 1.0]', $pdf);
+        $this->assertStringContainsString('/C0 [0.0000 0.0000 0.0000 0.0000]', $pdf);
+        $this->assertStringContainsString('/C1 [0.5000 0.0000 1.0000 0.2000]', $pdf);
+        $this->assertStringContainsString('/N 1.0', $pdf);
+    }
+
+    public function testAlternateSpaceRgb(): void
+    {
+        $cs = new SeparationColorSpace(
+            'Highlight',
+            new DeviceRgb(),
+            new ExponentialFunction([1.0, 1.0, 1.0], [1.0, 0.0, 0.0]),
+        );
+        $pdf = (new PdfSerializer(compress: false))->serialize($this->createCatalog($cs));
+
+        $this->assertMatchesRegularExpression('#\[/Separation /Highlight /DeviceRGB \d+ 0 R\]#', $pdf);
+    }
+
+    public function testCustomExponent(): void
+    {
+        $cs = new SeparationColorSpace(
+            'Spot',
+            new DeviceCmyk(),
+            new ExponentialFunction([0.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0], 2.2),
+        );
+        $pdf = (new PdfSerializer(compress: false))->serialize($this->createCatalog($cs));
+
+        $this->assertStringContainsString('/N 2.2', $pdf);
+    }
+}


### PR DESCRIPTION
## Summary

- Add PDF function infrastructure (PdfFunction interface, ExponentialFunction Type 2, PostScriptFunction Type 4)
- Implement SeparationColorSpace for single spot colors (Pantone etc.)
- Implement DeviceNColorSpace for multiple spot colors
- Generalize ResourceDictionary and ContentStreamBuilder from IccBasedColorSpace to ColorSpace interface
- PdfSerializer emits /ColorSpace resource dict entries with polymorphic dispatch for ICC, Separation and DeviceN

## Test plan

- [x] ExponentialFunction stores c0/c1/exponent, returns correct type/domain/range
- [x] PostScriptFunction stores code/domain/range
- [x] SeparationColorSpace has componentCount 1, stores colorant/alternate/transform
- [x] DeviceNColorSpace componentCount matches colorant array
- [x] SeparationColor emits correct cs/sc operators
- [x] DeviceNColor validates tint count, emits correct operators
- [x] Serializer produces [/Separation /name /alternate fnRef] array objects
- [x] Serializer produces [/DeviceN [...] /alternate fnRef] array objects
- [x] Type 2 function serialized with /FunctionType 2, /C0, /C1, /N
- [x] Type 4 PostScript function stream serialized correctly
- [x] Full regression suite passes (570 tests)